### PR TITLE
LBSD-1029 Prevent form submit on Enter key

### DIFF
--- a/client/app/scripts/liveblog-bloglist/module.js
+++ b/client/app/scripts/liveblog-bloglist/module.js
@@ -153,6 +153,21 @@
             $scope.creationStep = newTab;
         };
 
+        $scope.handleKeyDown = function(event, action) {
+            //prevent form submission and editor 'artifact'
+            if (event.keyCode === 13) {
+                event.preventDefault();
+                switch(action) {
+                    case 'goToTeamTab':
+                        //we need at least a valid title from the first tab
+                        if ($scope.newBlog.title) {
+                            $scope.switchTab('Team');
+                        }
+                        break;
+                }
+            }
+        };
+
         $scope.addMember = function(user) {
             $scope.blogMembers.push(user);
         };

--- a/client/app/scripts/liveblog-bloglist/views/main.html
+++ b/client/app/scripts/liveblog-bloglist/views/main.html
@@ -116,7 +116,7 @@
                         <fieldset>
                             <div class="field">
                                 <label translate>Blog title</label>
-                                <input type="text" ng-model="newBlog.title" required>
+                                <input type="text" ng-model="newBlog.title" required ng-keydown="handleKeyDown($event, 'goToTeamTab')">
                             </div>
                             <div class="field">
                                 <label translate>Blog description</label>


### PR DESCRIPTION
When pressing the Enter key in the title field, an unwanted "Add to dictionary" dialog opened in the blog description area. Now the Enter key forwards the form to the next page if the condition is met.