### PR TITLE
LBSD-1091:  Add api_url to consumer resource

### DIFF
--- a/client/app/scripts/liveblog-syndication/directives/consumer-edit.js
+++ b/client/app/scripts/liveblog-syndication/directives/consumer-edit.js
@@ -24,6 +24,9 @@ liveblogSyndication
                     if (!scope.consumerForm.name.$pristine)
                         data.name = scope.consumer.name;
 
+                    if (!scope.consumerForm.api_url.$pristine)
+                        data.api_url = scope.consumer.api_url;
+
                     if (scope.isEditing)
                         apiQuery = api.save('consumers', scope.origConsumer, data);
                     else

--- a/client/app/scripts/liveblog-syndication/views/consumer-edit-form.html
+++ b/client/app/scripts/liveblog-syndication/views/consumer-edit-form.html
@@ -19,7 +19,7 @@
             <div class="title">{{ 'General' | translate }} <span class="required-info" translate>* mandatory fields</span></div>
             <fieldset class="label-light">
                 <div sd-info-item>
-                  <label for="first-name" translate>name</label>
+                  <label for="name" translate>name</label>
                   <input 
                     type="text" 
                     name="name" 
@@ -28,7 +28,16 @@
                     required ng-readonly="consumer._readonly && consumer._readonly.name">
                   <i ng-show="consumerForm.name.$error.required" class="required-asteriks">*</i>
                 </div>
-
+                <div sd-info-item>
+                  <label for="api-url" translate>Api Url</label>
+                  <input
+                    type="text"
+                    name="api_url"
+                    id="api-url"
+                    ng-model="consumer.api_url"
+                    required ng-readonly="producer._readonly && producer._readonly.api_url">
+                  <i ng-show="consumerForm.api_url.$error.required" class="required-asteriks">*</i>
+                </div>
             </fieldset>
         </div>
     </div>

--- a/client/app/scripts/liveblog-syndication/views/consumer-list-item.html
+++ b/client/app/scripts/liveblog-syndication/views/consumer-list-item.html
@@ -12,6 +12,7 @@
 
     <div class="row-wrapper" sd-col-width>
         <div class="name">{{ consumer.name }}</div>
+        <div class="api_url">{{ consumer.api_url }}</div>
         <div class="api_key">{{ consumer.api_key }}</div>
     </div>
 

--- a/client/app/scripts/liveblog-syndication/views/consumer-list-item.html
+++ b/client/app/scripts/liveblog-syndication/views/consumer-list-item.html
@@ -12,11 +12,11 @@
 
     <div class="row-wrapper" sd-col-width>
         <div class="name">{{ consumer.name }}</div>
-        <div class="api_url">{{ consumer.api_url }}</div>
         <div class="api_key">
             <span id="api-key">{{ consumer.api_key }}</span>
             <span lb-copy-to-clipboard for="api-key"></span>
         </div>
+        <div class="api_url">{{ consumer.api_url }}</div>
     </div>
 
     <div class="action">

--- a/client/app/scripts/liveblog-syndication/views/consumer-list.html
+++ b/client/app/scripts/liveblog-syndication/views/consumer-list.html
@@ -32,6 +32,12 @@
                                         sd-sort 
                                         data-label="{{ 'Api key' | translate }}" 
                                         data-field="api_key"></div>
+
+                                    <div
+                                        class="api_url"
+                                        sd-sort
+                                        data-label="{{ 'Api url' | translate }}"
+                                        data-field="api_url"></div>
                                 </div>
                             </li>
                         </ul>

--- a/server/features/syndication_consumers.feature
+++ b/server/features/syndication_consumers.feature
@@ -5,7 +5,7 @@ Feature: Consumer Resource
         Given empty "consumers"
         When we post to "consumers"
         """
-        [{"name": "Consumer 1", "api_url": "http://localhost:5000/api":, "contacts": [{"first_name": "Foo", "last_name": "Bar", "email": "foo@bar.tld", "phone": "+49123456789"}]}]
+        [{"name": "Consumer 1", "api_url": "http://localhost:5000/api", "contacts": [{"first_name": "Foo", "last_name": "Bar", "email": "foo@bar.tld", "phone": "+49123456789"}]}]
         """
         Then we get OK response
         Then we get existing resource

--- a/server/features/syndication_consumers.feature
+++ b/server/features/syndication_consumers.feature
@@ -5,12 +5,12 @@ Feature: Consumer Resource
         Given empty "consumers"
         When we post to "consumers"
         """
-        [{"name": "Consumer 1", "contacts": [{"first_name": "Foo", "last_name": "Bar", "email": "foo@bar.tld", "phone": "+49123456789"}]}]
+        [{"name": "Consumer 1", "api_url": "http://localhost:5000/api":, "contacts": [{"first_name": "Foo", "last_name": "Bar", "email": "foo@bar.tld", "phone": "+49123456789"}]}]
         """
         Then we get OK response
         Then we get existing resource
         """
-        {"name": "Consumer 1", "contacts": [{"first_name": "Foo", "last_name": "Bar", "email": "foo@bar.tld", "phone": "+49123456789"}], "api_key": "#consumers.api_key#"}
+        {"name": "Consumer 1", "api_url": "http://localhost:5000/api", "contacts": [{"first_name": "Foo", "last_name": "Bar", "email": "foo@bar.tld", "phone": "+49123456789"}], "api_key": "#consumers.api_key#"}
         """
 
     @auth
@@ -18,8 +18,8 @@ Feature: Consumer Resource
         Given "consumers"
         """
         [
-            {"name": "Consumer 1", "contacts": [{"first_name": "Foo", "last_name": "Bar", "email": "foo@bar.tld", "phone": "+49123456789"}]},
-            {"name": "Consumer 2", "contacts": [{"first_name": "Boo", "last_name": "Baz", "email": "boo@baz.tld", "phone": "+49987654321"}]}
+            {"name": "Consumer 1", "api_url": "http://localhost:5000/api", "contacts": [{"first_name": "Foo", "last_name": "Bar", "email": "foo@bar.tld", "phone": "+49123456789"}]},
+            {"name": "Consumer 2", "api_url": "http://localhost:5000/api", "contacts": [{"first_name": "Boo", "last_name": "Baz", "email": "boo@baz.tld", "phone": "+49987654321"}]}
         ]
         """
         When we get "/consumers"
@@ -33,7 +33,7 @@ Feature: Consumer Resource
     Scenario: Update consumer
         Given "consumers"
         """
-        [{"name": "Consumer 1", "contacts": [{"first_name": "Foo", "last_name": "Bar", "email": "foo@bar.tld", "phone": "+49123456789"}]}]
+        [{"name": "Consumer 1", "api_url": "http://localhost:5000/api", "contacts": [{"first_name": "Foo", "last_name": "Bar", "email": "foo@bar.tld", "phone": "+49123456789"}]}]
         """
         When we find for "consumers" the id as "consumer_id" by "where={"name": "Consumer 1"}"
         And we patch "/consumers/#consumer_id#"
@@ -46,7 +46,7 @@ Feature: Consumer Resource
     Scenario: Delete consumer
         Given "consumers"
         """
-        [{"name": "Consumer 1", "contacts": [{"first_name": "Foo", "last_name": "Bar", "email": "foo@bar.tld", "phone": "+49123456789"}]}]
+        [{"name": "Consumer 1", "api_url": "http://localhost:5000/api", "contacts": [{"first_name": "Foo", "last_name": "Bar", "email": "foo@bar.tld", "phone": "+49123456789"}]}]
         """
         When we find for "consumers" the id as "consumer_id" by "where={"name": "Consumer 1"}"
         And we delete "/consumers/#consumer_id#"

--- a/server/features/syndication_producers.feature
+++ b/server/features/syndication_producers.feature
@@ -78,7 +78,7 @@ Feature: Producer Resource
         Given "consumers"
         """
         [
-            {"name": "Consumer", "contacts": [{"first_name": "Foo", "last_name": "Bar", "email": "foo@bar.tld", "phone": "+49123456789"}], "api_key": "__any_value__"}
+            {"name": "Consumer", "api_url": "http://localhost:5000/api", "contacts": [{"first_name": "Foo", "last_name": "Bar", "email": "foo@bar.tld", "phone": "+49123456789"}], "api_key": "__any_value__"}
         ]
         """
         Given "producers"

--- a/server/liveblog/syndication/consumer.py
+++ b/server/liveblog/syndication/consumer.py
@@ -34,8 +34,11 @@ consumers_schema = {
     },
     'api_key': {
         'type': 'string',
-        'nullable': True,
         'unique': True
+    },
+    'api_url': {
+        'type': 'string',
+        'required': True
     }
 }
 


### PR DESCRIPTION
Add api_url to consumer resource. We need to add api_url to consumer resource. This is required to get the syndication webhook working. We no longer need to define a target_url for syndicate webhook.