### PR TITLE
Update files for running liveblog with docker on windows

### DIFF
--- a/docker/common.yml
+++ b/docker/common.yml
@@ -1,18 +1,16 @@
 mongodb:
   image: mongo:2.6
-  volumes:
-   - ../data/mongodb:/data/db
 
 redis:
   image: redis:2.8
   volumes:
-   - ../data/redis:/data
+    - ../data/redis:/data
 
 logstash:
   image: logstash:1.5
   command: logstash -f /usr/share/logstash/logstash.conf
   volumes:
-  - ./logstash:/usr/share/logstash
+    - ./logstash:/usr/share/logstash
 
 kibana:
   build: kibana
@@ -21,45 +19,45 @@ kibana:
 elastic:
   image: elasticsearch:1.5
   volumes:
-   - ../data/elastic:/usr/share/elasticsearch/data
+    - ../data/elastic:/usr/share/elasticsearch/data
 
 postfix:
   image: catatnight/postfix
   environment:
-  - maildomain=mail.sourcefabric.org
-  - smtp_user=user:pwd
+    - maildomain=mail.sourcefabric.org
+    - smtp_user=user:pwd
 
 superdesk:
   build: ../
   environment:
-   - MONGO_URI=mongodb://mongodb/test
-   - PUBLICAPI_MONGO_URI=mongodb://mongodb/test
-   - LEGAL_ARCHIVE_URI=mongodb://mongodb/test
-   - ELASTICSEARCH_URL=http://elastic:9200
-   - ELASTICSEARCH_INDEX
-   - CELERY_BROKER_URL=redis://redis:6379/1
-   - REDIS_URL=redis://redis:6379/1
-   - LOG_SERVER_ADDRESS=logstash
-   - LOG_SERVER_PORT=5555
-   - AMAZON_ACCESS_KEY_ID
-   - AMAZON_CONTAINER_NAME
-   - AMAZON_REGION
-   - AMAZON_SECRET_ACCESS_KEY
-   - S3_THEMES_PREFIX
-   - REUTERS_USERNAME
-   - REUTERS_PASSWORD
-   - MAIL_SERVER=postfix
-   - MAIL_PORT=25
-   - MAIL_USE_TLS=false
-   - MAIL_USE_SSL=false
-   - MAIL_USERNAME=user
-   - MAIL_PASSWORD=pwd
-   - SENTRY_DSN
-   - SUPERDESK_URL=http://127.0.0.1/api
-   - SUPERDESK_WS_URL=ws://127.0.0.1/ws
-   - SUPERDESK_CLIENT_URL=http://127.0.0.1
-   - SUPERDESK_TESTING=True
+    - MONGO_URI=mongodb://mongodb/test
+    - PUBLICAPI_MONGO_URI=mongodb://mongodb/test
+    - LEGAL_ARCHIVE_URI=mongodb://mongodb/test
+    - ELASTICSEARCH_URL=http://elastic:9200
+    - ELASTICSEARCH_INDEX
+    - CELERY_BROKER_URL=redis://redis:6379/1
+    - REDIS_URL=redis://redis:6379/1
+    - LOG_SERVER_ADDRESS=logstash
+    - LOG_SERVER_PORT=5555
+    - AMAZON_ACCESS_KEY_ID
+    - AMAZON_CONTAINER_NAME
+    - AMAZON_REGION
+    - AMAZON_SECRET_ACCESS_KEY
+    - S3_THEMES_PREFIX
+    - REUTERS_USERNAME
+    - REUTERS_PASSWORD
+    - MAIL_SERVER=postfix
+    - MAIL_PORT=25
+    - MAIL_USE_TLS=false
+    - MAIL_USE_SSL=false
+    - MAIL_USERNAME=user
+    - MAIL_PASSWORD=pwd
+    - SENTRY_DSN
+    - SUPERDESK_URL=http://127.0.0.1/api
+    - SUPERDESK_WS_URL=ws://127.0.0.1/ws
+    - SUPERDESK_CLIENT_URL=http://127.0.0.1
+    - SUPERDESK_TESTING=True
   volumes:
-   - ../results/server/unit:/opt/superdesk/results-unit/
-   - ../results/server/behave:/opt/superdesk/results-behave/
-   - ../results/client/unit:/opt/superdesk/client/unit-test-results
+    - ../results/server/unit:/opt/superdesk/results-unit/
+    - ../results/server/behave:/opt/superdesk/results-behave/
+    - ../results/client/unit:/opt/superdesk/client/unit-test-results

--- a/docker/docker-compose-dev.yml
+++ b/docker/docker-compose-dev.yml
@@ -3,7 +3,7 @@ logstash:
     file: common.yml
     service: logstash
   links:
-  - elastic
+    - elastic
 
 mongodb:
   extends:
@@ -20,9 +20,9 @@ kibana:
     file: common.yml
     service: kibana
   links:
-  - elastic
+    - elastic
   ports:
-  - "5601:5601"
+    - "5601:5601"
 
 elastic:
   extends:
@@ -39,23 +39,28 @@ superdesk:
     file: common.yml
     service: superdesk
   links:
-   - mongodb
-   - redis
-   - elastic
-   - logstash
-   - postfix
+    - mongodb
+    - redis
+    - elastic
+    - logstash
+    - postfix
   environment:
-   - SUPERDESK_RELOAD=True
-   - SUPERDESK_URL=http://localhost:5000/api
-   - SUPERDESK_WS_URL=ws://localhost:5050
-   - SUPERDESK_CLIENT_URL=http://localhost:9000
+    - SUPERDESK_RELOAD=True
+    - SUPERDESK_URL=http://127.0.0.1:5000/api
+    - SUPERDESK_WS_URL=ws://127.0.0.1:5050
+    - SUPERDESK_CLIENT_URL=http://127.0.0.1:9000
+    - ELASTICSEARCH_URL=http://elastic:9200
+    - ELASTICSEARCH_INDEX
   ports:
-   - "5000:5000"
-   - "5100:5100"
-   - "9000:9000"
-   - "35729:35729"
+    - "5000:5000"
+    - "5100:5100"
+    - "9000:9000"
+    - "35729:35729"
+    - "443:443"
+    - "80:80"
   volumes:
-   - ../server:/opt/superdesk/
-   - ../client:/opt/superdesk/client/
-   - ./Procfile-dev:/opt/superdesk/Procfile
-   - ./start-dev.sh:/opt/superdesk/start.sh
+    - ../server:/opt/superdesk/
+    - ../client:/opt/superdesk/client/
+    - ./Procfile-dev:/opt/superdesk/Procfile
+  command:
+    honcho start

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -9,6 +9,8 @@ mongodb:
   extends:
     file: ../docker/common.yml
     service: mongodb
+  volumes:
+   - ../data/mongodb:/data/db
 
 redis:
   extends:

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -14,4 +14,5 @@ httmock
 honcho
 # Superdesk
 -e git+git://github.com/liveblog/superdesk-core.git@2d76fb0ffaaa6aac1835fe44486144282cd0c5ce#egg=Superdesk-Core==1.06-update-sd-core
+lxml
 


### PR DESCRIPTION
Restructured Dockerfile and replaced npm install with npm-install-que to enable the build on machines with slow internet and limited main memory.

Updated common.yml and removed the volume for mongoDB, because this is not working when docker is running in a VM.

Updated docker-compose.yml to include the mongoDB volume again.

Updated docker-compose-dev.yml to use a different command for startup.

I would be interested in what is supposed to happen. The scripts did not give me a high level understanding.
