### PR TITLE
LBSD-1209: Change order of posts for autopublish on syndication

### DIFF
--- a/server/liveblog/syndication/tasks.py
+++ b/server/liveblog/syndication/tasks.py
@@ -43,6 +43,9 @@ def send_posts_to_consumer(self, syndication_out, action='created', limit=25, po
     if not start_date and limit:
         posts = posts.limit(limit)
 
+    # Sort posts by _updated ASC
+    posts = posts.sort('_updated', 1)
+
     try:
         for producer_post in posts:
             items = extract_post_items_data(producer_post)

--- a/server/liveblog/syndication/utils.py
+++ b/server/liveblog/syndication/utils.py
@@ -258,7 +258,9 @@ def create_syndicated_blog_post(producer_post, items, in_syndication):
         'syndication_in': in_syndication['_id'],
         'particular_type': 'post',
         'post_status': post_status,
-        'producer_post_id': producer_post_id
+        'producer_post_id': producer_post_id,
+        # TODO: python-eve doesn't allow to replace _updated value, as post/put/patch method force it to now()
+        # '_updated': producer_post['_updated']
     }
     return new_post
 


### PR DESCRIPTION
Posts in syndicated blog on consumer side were ordered differently than on the producer's side when autopublish was enabled. The proposed bugfix changes the sorting of the blog posts, as unfortunately python-eve doesn't allow to update _updated or _inserted date values, that are always set to datetime.datetime.now() by the framework itself. We should have a different date field for blog posts sorting.