### PR TITLE
Add download CSV functionality to analytics view

### DIFF
--- a/client/app/scripts/liveblog-analytics/controllers/controller-analytics.js
+++ b/client/app/scripts/liveblog-analytics/controllers/controller-analytics.js
@@ -19,12 +19,11 @@ function LiveblogAnalyticsController($scope, $location, api, analytics, blog, no
   };
 
   var downloadCSV = function() { // Convert relevant item fields to CSV
-    var fileContent = "data:text/csv;charset=utf-8,"
-      , filename = "liveblog_analytics_" + blog._id;
+    var fileContent = "", filename = "liveblog_analytics_" + blog._id;
 
     $scope.analytics_data._items.forEach(function(arr, index) {
       var item = $scope.analytics_data._items[index]
-        , filtered = [item.blog_id, item.context_url, item.hits]
+        , filtered = [item.blog_id, item.context_url, item.hits];
       fileContent += filtered.join(",") + "\n"
     });
 
@@ -54,7 +53,7 @@ function LiveblogAnalyticsController($scope, $location, api, analytics, blog, no
     blog: blog,
     close: close,
     tab: "embeds",
-    downloadCSV: download_csv,
+    downloadCSV: downloadCSV,
     changeTab: function(tab) {
       vm.tab = tab;
       if (!vm.tab) return;

--- a/client/app/scripts/liveblog-analytics/controllers/controller-analytics.js
+++ b/client/app/scripts/liveblog-analytics/controllers/controller-analytics.js
@@ -18,7 +18,7 @@ function LiveblogAnalyticsController($scope, $location, api, analytics, blog, no
     })
   };
 
-  var download_csv = function() { // Convert relevant item fields to CSV
+  var downloadCSV = function() { // Convert relevant item fields to CSV
     var fileContent = "data:text/csv;charset=utf-8,"
       , filename = "liveblog_analytics_" + blog._id;
 
@@ -54,7 +54,7 @@ function LiveblogAnalyticsController($scope, $location, api, analytics, blog, no
     blog: blog,
     close: close,
     tab: "embeds",
-    download_csv: download_csv,
+    downloadCSV: download_csv,
     changeTab: function(tab) {
       vm.tab = tab;
       if (!vm.tab) return;

--- a/client/app/scripts/liveblog-analytics/views/view-analytics.html
+++ b/client/app/scripts/liveblog-analytics/views/view-analytics.html
@@ -36,7 +36,7 @@
                     <div class="content content--analytics">
                         <div ng-if="analytics_data">                            
                             <button class="btn btn-info pull-right mod--absoluteright" ng-click="" translate="">
-                                <span class="ng-scope">Download CSV</span>
+                                <span class="ng-scope" ng-click="analytics.download_csv()">Download CSV</span>
                             </button>
                             <lb-analytics-list showSourceBadge="false" loadMore="loadMore()"" analytics="analytics_data"></lb-analytics-list>
                         </div>

--- a/client/app/scripts/liveblog-analytics/views/view-analytics.html
+++ b/client/app/scripts/liveblog-analytics/views/view-analytics.html
@@ -36,7 +36,7 @@
                     <div class="content content--analytics">
                         <div ng-if="analytics_data">                            
                             <button class="btn btn-info pull-right mod--absoluteright" ng-click="" translate="">
-                                <span class="ng-scope" ng-click="analytics.download_csv()">Download CSV</span>
+                                <span class="ng-scope" ng-click="analytics.downloadCSV()">Download CSV</span>
                             </button>
                             <lb-analytics-list showSourceBadge="false" loadMore="loadMore()"" analytics="analytics_data"></lb-analytics-list>
                         </div>


### PR DESCRIPTION
Transform analytics items to CSV, download via `link.download` as opposed to `window.open`. Should work with any HTML5 capable browser and IE, cf. http://caniuse.com/#search=download. Code is linted this time around.