### PR TITLE
LP-34 - In client, limit number of active blogs depending on subscription level

### DIFF
--- a/client/app/scripts/liveblog-bloglist/module.js
+++ b/client/app/scripts/liveblog-bloglist/module.js
@@ -65,12 +65,20 @@
             clearCreateBlogForm();
             $scope.newBlogModalActive = false;
         };
+
+        $scope.cancelUpgrade = function() {
+            $scope.embedUpgrade = false;
+        };
+
         $scope.openNewBlog = function() {
-            //console.log('blogs', $scope.blogs);
-            if (blogSecurityService.showUpgradeModal($scope.blogs))
-                $scope.embedUpgrade = true;
-            else
-                $scope.newBlogModalActive = true;
+            blogSecurityService
+                .showUpgradeModal()
+                .then(function(showUpgradeModal) {
+                    if (showUpgradeModal)
+                        $scope.embedUpgrade = true;
+                    else
+                        $scope.newBlogModalActive = true;
+                });
         };
 
         $scope.createBlog = function() {

--- a/client/app/scripts/liveblog-bloglist/module.js
+++ b/client/app/scripts/liveblog-bloglist/module.js
@@ -66,7 +66,11 @@
             $scope.newBlogModalActive = false;
         };
         $scope.openNewBlog = function() {
-            $scope.newBlogModalActive = true;
+            //console.log('blogs', $scope.blogs);
+            if (blogSecurityService.showUpgradeModal($scope.blogs))
+                $scope.embedUpgrade = true;
+            else
+                $scope.newBlogModalActive = true;
         };
 
         $scope.createBlog = function() {

--- a/client/app/scripts/liveblog-bloglist/views/main.html
+++ b/client/app/scripts/liveblog-bloglist/views/main.html
@@ -98,7 +98,17 @@
     <div sd-modal="" data-model="embedUpgrade">
         <div class="modal-header">
             <button class="close" ng-click="cancelUpgrade()"><i class="icon-close-small"></i></button>
-            <h3 translate>Please upgrade to create a new blog!</h3>
+            <h3 translate>Sorry</h3>
+        </div>
+        <div class="modal-body">
+            <p translate>You have reached the maximum number of users who are assigned as team members to your active blogs. You can either:</p>
+            <ul>
+                <li translate>1. Unassign a team member from one of your active blogs or</li>
+                <li translate>2. Subscribe to a bigger plan.</li>
+            </ul>
+            <br/>
+            <p translate>To unassign a team member from one of your active blogs, go to “Blog settings”, choose “Team” and open the “Team members” section. Unassign a team member by clicking on the X.</p>
+            <p translate>Want to upgrade to a plan more suitable to your needs? Email us at <a href="mailto:upgrade@liveblog.pro">upgrade@liveblog.pro</a> and tell us when and how we can best contact you to take your order.</p>
         </div>
     </div>
 

--- a/client/app/scripts/liveblog-bloglist/views/main.html
+++ b/client/app/scripts/liveblog-bloglist/views/main.html
@@ -101,13 +101,13 @@
             <h3 translate>Sorry</h3>
         </div>
         <div class="modal-body">
-            <p translate>You have reached the maximum number of users who are assigned as team members to your active blogs. You can either:</p>
+            <p translate>You have reached the maximum number of active blogs on your Live Blog plan. You can either:</p>
             <ul>
-                <li translate>1. Unassign a team member from one of your active blogs or</li>
+                <li translate>1. Archive an active blog or</li>
                 <li translate>2. Subscribe to a bigger plan.</li>
             </ul>
-            <br/>
-            <p translate>To unassign a team member from one of your active blogs, go to “Blog settings”, choose “Team” and open the “Team members” section. Unassign a team member by clicking on the X.</p>
+            <br />
+            <p translate>To archive a blog, go to blog settings and change the blog status from “active” to “archived.”</p>
             <p translate>Want to upgrade to a plan more suitable to your needs? Email us at <a href="mailto:upgrade@liveblog.pro">upgrade@liveblog.pro</a> and tell us when and how we can best contact you to take your order.</p>
         </div>
     </div>

--- a/client/app/scripts/liveblog-bloglist/views/main.html
+++ b/client/app/scripts/liveblog-bloglist/views/main.html
@@ -95,6 +95,13 @@
         </ul>
     </div>
 
+    <div sd-modal="" data-model="embedUpgrade">
+        <div class="modal-header">
+            <button class="close" ng-click="cancelUpgrade()"><i class="icon-close-small"></i></button>
+            <h3 translate>Please upgrade to create a new blog!</h3>
+        </div>
+    </div>
+
     <div sd-modal="" data-model="embedModal">
             <div class="modal-header">
                 <button class="close" ng-click="cancelEmbed()"><i class="icon-close-small"></i></button>

--- a/client/app/scripts/liveblog-edit/controllers/blog-settings.js
+++ b/client/app/scripts/liveblog-edit/controllers/blog-settings.js
@@ -18,7 +18,7 @@ define([
 ], function(angular, _) {
     'use strict';
     var BlogSettingsController = function($scope, blog, api, blogService, $location, notify,
-        gettext, modal, $q, upload, config) {
+        gettext, modal, $q, upload, config, blogSecurityService) {
 
         // set view's model
         var vm = this;
@@ -318,8 +318,13 @@ define([
         vm.changeTab('general');
         vm.blog_switch = vm.newBlog.blog_status === 'open'? true: false;
         vm.syndication_enabled = vm.newBlog.syndication_enabled;
+
+        // Deactivate status input, when too many blogs are active
+        blogSecurityService.showUpgradeModal().then(function(showUpgradeModal) {
+            vm.deactivateStatus = vm.blog_switch ? false : showUpgradeModal;
+        });
     }
     BlogSettingsController.$inject = ['$scope', 'blog', 'api', 'blogService', '$location', 'notify',
-        'gettext', 'modal', '$q', 'upload', 'config'];
+        'gettext', 'modal', '$q', 'upload', 'config', 'blogSecurityService'];
     return BlogSettingsController;
 });

--- a/client/app/scripts/liveblog-edit/views/settings.html
+++ b/client/app/scripts/liveblog-edit/views/settings.html
@@ -39,7 +39,8 @@
                         <form class="form-horizontal" name="settings.forms.general">
                             <div class="form-group">
                                 <label for="inputTitle" class="control-label" translate>Blog Status</label>
-                                <div class="form-input relative">
+                                <p ng-if="settings.deactivateStatus">Too many active blogs</p>
+                                <div class="form-input relative" ng-if="!settings.deactivateStatus">
                                     <span class="blog-status">{{ settings.blog_switch ? 'Active' : 'Archived' | translate }}</span>
                                     <span style="display: block" tooltip="{{ settings.blog_switch ? 'Archive Blog' : 'Activate Blog' | translate }}" tooltip-placement="right">
                                         <span class="pull-left" sd-switch ng-model="settings.blog_switch" data-blog-status-switch></span>

--- a/client/app/scripts/liveblog-security.service.js
+++ b/client/app/scripts/liveblog-security.service.js
@@ -21,7 +21,7 @@ angular.module('liveblog.security', [])
         }
         function showUpgradeModal() {
             if (!config.blogCreationRestrictions.hasOwnProperty(config.subscriptionLevel))
-                return false;
+                return $q.when(false);
 
             var numberOfAllowedBlogs = config.blogCreationRestrictions[config.subscriptionLevel];
 

--- a/client/app/scripts/liveblog-security.service.js
+++ b/client/app/scripts/liveblog-security.service.js
@@ -2,8 +2,8 @@
 
 angular.module('liveblog.security', [])
 .service('blogSecurityService',
-    ['$q', '$rootScope', '$route', 'blogService', '$location', 'privileges',
-    function($q, $rootScope, $route, blogService, $location, privileges) {
+    ['$q', '$rootScope', '$route', 'blogService', '$location', 'privileges', 'config',
+    function($q, $rootScope, $route, blogService, $location, privileges, config) {
         function canPublishAPost() {
             return privileges.userHasPrivileges({'publish_post': 1});
         }
@@ -18,6 +18,18 @@ angular.module('liveblog.security', [])
                 ids.push.apply(ids, blog.members.map(function(member) {return member.user;}));
             }
             return ids.indexOf($rootScope.currentUser._id) > -1;
+        }
+        function showUpgradeModal(blogs) {
+            if (!config.blogCreationRestrictions.hasOwnProperty(config.subscriptionLevel))
+                return false;
+
+            var numberOfAllowedBlogs = config.blogCreationRestrictions[config.subscriptionLevel];
+
+            var ownBlogs = blogs._items.filter(function(blog) {
+                return (blog.original_creator._id == $rootScope.currentUser._id);
+            })
+
+            return (ownBlogs.length >= numberOfAllowedBlogs);
         }
         function canAccessBlog(blog) {
             return isAdmin() || isMemberOfBlog(blog);
@@ -52,6 +64,7 @@ angular.module('liveblog.security', [])
         }
         return {
             goToSettings: goToSettings,
+            showUpgradeModal: showUpgradeModal,
             isAdmin: isAdmin,
             isUserOwnerOrAdmin: isUserOwnerOrAdmin,
             isUserOwnerOrCanPublishAPost: isUserOwnerOrCanPublishAPost,

--- a/client/tasks/options/template.js
+++ b/client/tasks/options/template.js
@@ -20,6 +20,10 @@ module.exports = function(grunt) {
             facebookAppId: grunt.option('facebook-appid') || process.env.FACEBOOK_APP_ID || '',
             syndication: process.env.SYNDICATION || false,
             subscriptionLevel: process.env.SUBSCRIPTION_LEVEL || '',
+            blogCreationRestrictions: {
+                solo: 1,
+                team: 3
+            },
             analytics: {
                 piwik: {
                     url: process.env.PIWIK_URL || '',


### PR DESCRIPTION
This PR is doing two things:

* Displaying a modal inviting the user to upgrade when trying to create more blogs than allowed.
* In blog settings, checking the number of active blogs before allowing to change the status from `archived` to `open`.