### PR TITLE
LP-40 - On client, limit number of themes for users with team level subscription

### DIFF
--- a/client/app/scripts/liveblog-themes/module.js
+++ b/client/app/scripts/liveblog-themes/module.js
@@ -89,6 +89,7 @@
             // TODO: Pagination
             return api.themes.query().then(function(data) {
                 var themes = data._items;
+                console.log('themes', themes);
                 themes.forEach(function(theme) {
                     // create criteria to load blogs with the theme.
                     var criteria = {
@@ -229,6 +230,19 @@
             openThemeSettings: function(theme) {
                 vm.themeSettingsModal = true;
                 vm.themeSettingsModalTheme = theme;
+            },
+            hasReachedThemesLimit: function() {
+                if (config.subscriptionLevel != 'team')
+                    return false;
+                else
+                    return true;
+            },
+            upgradeModal: false,
+            showUpgradeModal: function() {
+                vm.upgradeModal = true;
+            },
+            closeUpgradeModal: function() {
+                vm.upgradeModal = false;
             }
         });
 

--- a/client/app/scripts/liveblog-themes/module.js
+++ b/client/app/scripts/liveblog-themes/module.js
@@ -89,7 +89,6 @@
             // TODO: Pagination
             return api.themes.query().then(function(data) {
                 var themes = data._items;
-                console.log('themes', themes);
                 themes.forEach(function(theme) {
                     // create criteria to load blogs with the theme.
                     var criteria = {
@@ -232,10 +231,17 @@
                 vm.themeSettingsModalTheme = theme;
             },
             hasReachedThemesLimit: function() {
-                if (config.subscriptionLevel != 'team')
+                if (!vm.themes)
                     return false;
+
+                var themes = vm.themes.filter(function(theme) {
+                    return (theme.name != config.excludedTheme);
+                });
+
+                if (config.subscriptionLevel == 'team')
+                    return (themes.length >= config.themeCreationRestrictions.team);
                 else
-                    return true;
+                    return false;
             },
             upgradeModal: false,
             showUpgradeModal: function() {

--- a/client/app/scripts/liveblog-themes/views/list.html
+++ b/client/app/scripts/liveblog-themes/views/list.html
@@ -1,12 +1,27 @@
 <div class="subnav ng-scope themes-manager">
     <h3 class="page-nav-title" translate>Theme Manager</h3>
     <div class="button-stack right-stack">
-        <form action="#" method="post" enctype="multipart/form-data">
+        <form
+            action="#"
+            method="post"
+            enctype="multipart/form-data"
+            ng-if="!vm.hasReachedThemesLimit()">
             <label class="navbtn navbtn-info" for="uploadAThemeFile">
                 <i class="svg-icon-add inverse"></i> <span class="title" translate>New Theme</span>
             </label>
-            <input type="file" name="uploadAThemeFile" id="uploadAThemeFile" onchange="angular.element(this).controller().uploadThemeFile(this)">
+            <input
+                type="file" 
+                name="uploadAThemeFile" 
+                id="uploadAThemeFile" 
+                onchange="angular.element(this).controller().uploadThemeFile(this)">
         </form>
+
+        <button
+            ng-if="vm.hasReachedThemesLimit()"
+            class="navbtn navbtn-info"
+            ng-click="vm.showUpgradeModal()">
+            <i class="svg-icon-add inverse"></i> <span class="title" translate>New Theme</span>
+        </button>
     </div>
 </div>
 
@@ -115,5 +130,17 @@
             full-height-offset-bottom="50"/>
     </div>
 </div>
+
+<div sd-modal="" data-model="vm.upgradeModal">
+    <div class="modal-header">
+        <button class="close" ng-click="vm.closeUpgradeModal()">
+            <i class="icon-close-small"></i>
+        </button>
+    </div>
+    <div class="modal-body">
+        <p>Please ugrade if you want to add more themes</p>
+    </div>
+</div>
+
 
 <theme-settings-modal theme="vm.themeSettingsModalTheme" ng-if="vm.themeSettingsModalTheme"></theme-settings-modal>

--- a/client/app/scripts/liveblog-themes/views/list.html
+++ b/client/app/scripts/liveblog-themes/views/list.html
@@ -136,9 +136,17 @@
         <button class="close" ng-click="vm.closeUpgradeModal()">
             <i class="icon-close-small"></i>
         </button>
+        <h3>Sorry</h3>
     </div>
     <div class="modal-body">
-        <p>Please ugrade if you want to add more themes</p>
+      <p>You have reached the maximum number of themes on your Live Blog plan. You can either:</p>
+      <ul>
+        <li>1. Remove an existing theme or</li>
+        <li>2. Subscribe to a bigger plan.</li>
+      </ul>
+      <br/>
+      <p>To remove a theme from your Live Blog instance, click on the burger menu on the top left and open the Theme Manager. You can now delete a theme by clicking on the “Remove” button.</p>
+      <p>Want to upgrade to a plan more suitable to your needs? Email us at <a href="mailto:upgrade@liveblog.pro">upgrade@liveblog.pro</a> and tell us when and how we can best contact you to take your order.</p>
     </div>
 </div>
 

--- a/client/tasks/options/template.js
+++ b/client/tasks/options/template.js
@@ -19,6 +19,7 @@ module.exports = function(grunt) {
             },
             facebookAppId: grunt.option('facebook-appid') || process.env.FACEBOOK_APP_ID || '',
             syndication: process.env.SYNDICATION || false,
+            themeCreationRestrictions: { team: 3 },
             subscriptionLevel: process.env.SUBSCRIPTION_LEVEL || '',
             analytics: {
                 piwik: {

--- a/client/tasks/options/template.js
+++ b/client/tasks/options/template.js
@@ -19,7 +19,8 @@ module.exports = function(grunt) {
             },
             facebookAppId: grunt.option('facebook-appid') || process.env.FACEBOOK_APP_ID || '',
             syndication: process.env.SYNDICATION || false,
-            themeCreationRestrictions: { team: 3 },
+            themeCreationRestrictions: {team: 3},
+            excludedTheme: 'angular',
             subscriptionLevel: process.env.SUBSCRIPTION_LEVEL || '',
             analytics: {
                 piwik: {


### PR DESCRIPTION
Limit the number of allowed themes to 3 (excluded angular theme) for team instances.