### PR TITLE
Lp 49 - Restore theme manager access for solo users (SAAS)

### DIFF
--- a/client/app/scripts/liveblog-themes/module.js
+++ b/client/app/scripts/liveblog-themes/module.js
@@ -129,6 +129,7 @@
             themeBlogsModal: false,
             // this is used to when a blog is selected.
             selectedBlog: false,
+            isSolo: config.subscriptionLevel == 'solo',
             // loading indicatior for the first timeload.
             loading: true,
             getTheme: function(name) {

--- a/client/app/scripts/liveblog-themes/module.js
+++ b/client/app/scripts/liveblog-themes/module.js
@@ -261,17 +261,16 @@
 
     var liveblogThemeModule = angular.module('liveblog.themes', [])
     .config(['superdeskProvider', 'config', function(superdesk, config) {
-        if (config.subscriptionLevel != 'solo')
-            superdesk
-                .activity('/themes/', {
-                    label: gettext('Theme Manager'),
-                    controller: LiveblogThemesController,
-                    controllerAs: 'vm',
-                    category: superdesk.MENU_MAIN,
-                    adminTools: true,
-                    privileges: {'global_preferences': 1},
-                    templateUrl: 'scripts/liveblog-themes/views/list.html'
-                });
+        superdesk
+            .activity('/themes/', {
+                label: gettext('Theme Manager'),
+                controller: LiveblogThemesController,
+                controllerAs: 'vm',
+                category: superdesk.MENU_MAIN,
+                adminTools: true,
+                privileges: {'global_preferences': 1},
+                templateUrl: 'scripts/liveblog-themes/views/list.html'
+            });
     }])
     .filter('githubUrlFromGit', function() {
         return function(string) {

--- a/client/app/scripts/liveblog-themes/views/list.html
+++ b/client/app/scripts/liveblog-themes/views/list.html
@@ -60,8 +60,8 @@
                                         {{ ::theme.author.name }}
                                     </div>
                                 </dd>
-                                <dt ng-if="vm.isSolo()">{{ ::'Sources' | translate }}:</dt>
-                                <dd ng-if="vm.isSolo()">
+                                <dt ng-if="!vm.isSolo()">{{ ::'Sources' | translate }}:</dt>
+                                <dd ng-if="!vm.isSolo()">
                                     <div ng-if="!theme.repository.url">unavailable</div>
                                     <a href="{{::theme.repository.url | githubUrlFromGit}}/archive/master.zip"
                                        ng-if="theme.repository.url"

--- a/client/app/scripts/liveblog-themes/views/list.html
+++ b/client/app/scripts/liveblog-themes/views/list.html
@@ -5,7 +5,7 @@
             action="#"
             method="post"
             enctype="multipart/form-data"
-            ng-if="!vm.hasReachedThemesLimit()">
+            ng-if="!vm.hasReachedThemesLimit() && !vm.isSolo()">
             <label class="navbtn navbtn-info" for="uploadAThemeFile">
                 <i class="svg-icon-add inverse"></i> <span class="title" translate>New Theme</span>
             </label>
@@ -28,7 +28,12 @@
 <section class="main-section themelist">
     <div class="loading-indicator" ng-show="vm.loading"><span translate>loading</span></div>
     <div class="list-container">
-        <div class="alert alert-info alert--margin-left" role="alert"><button type="button" class="close" data-dismiss="alert" aria-label="Close"><i class="icon-close-small"></i></button>Customize your themes to the specific needs of your organisation. All you need is someone in your team with frontend development skills and a download of the classic theme as a good starting point to create your own. You find all required code and some info on Github: <a href="https://github.com/liveblog/liveblog/blob/e7945a48fcd19c1a959d8e83706114f13864871c/CUSTOM-THEME.MD" target="_blank">https://github.com/liveblog/liveblog/blob/e7945a48fcd19c1a959d8e83706114f13864871c/CUSTOM-THEME.MD</a></div>
+        <div 
+            ng-if="!vm.isSolo()"
+            class="alert alert-info alert--margin-left" 
+            role="alert">
+            <button type="button" class="close" data-dismiss="alert" aria-label="Close"><i class="icon-close-small"></i></button>Customize your themes to the specific needs of your organisation. All you need is someone in your team with frontend development skills and a download of the classic theme as a good starting point to create your own. You find all required code and some info on Github: <a href="https://github.com/liveblog/liveblog/blob/e7945a48fcd19c1a959d8e83706114f13864871c/CUSTOM-THEME.MD" target="_blank">https://github.com/liveblog/liveblog/blob/e7945a48fcd19c1a959d8e83706114f13864871c/CUSTOM-THEME.MD</a>
+        </div>
         <!-- LIST VIEW -->
         <script type="text/ng-template" id="themeTree">
             <ul>
@@ -55,8 +60,8 @@
                                         {{ ::theme.author.name }}
                                     </div>
                                 </dd>
-                                <dt>{{ ::'Sources' | translate }}:</dt>
-                                <dd>
+                                <dt ng-if="vm.isSolo()">{{ ::'Sources' | translate }}:</dt>
+                                <dd ng-if="vm.isSolo()">
                                     <div ng-if="!theme.repository.url">unavailable</div>
                                     <a href="{{::theme.repository.url | githubUrlFromGit}}/archive/master.zip"
                                        ng-if="theme.repository.url"
@@ -83,7 +88,12 @@
                                 <button ng-if="!theme.abstract" ng-click="vm.makeDefault(theme)" class="btn btn-info pull-right" type="button" translate>Make default</button>
                             </div>
                             <button ng-click="vm.openThemeSettings(theme)" class="btn btn-default pull-right" type="button" translate>Settings</button>
-                            <button ng-click="vm.download(theme)" class="btn btn-info pull-right" type="button" translate>Download</button>
+                            <button
+                                ng-if="!vm.isSolo()"
+                                ng-click="vm.download(theme)"
+                                class="btn btn-info pull-right"
+                                type="button"
+                                translate>Download</button>
                         </div>
                         <div class="default-theme" ng-show="vm.isDefaultTheme(theme)"></div>
                     </div>


### PR DESCRIPTION
* Restore theme manager for `solo` users
* Hide open source alert message
* Hide github link in themes list
* Hide new theme button
* Hide download theme