### PR TITLE
Added a marketplace switch in blog settings

### DIFF
--- a/client/app/index.html
+++ b/client/app/index.html
@@ -214,6 +214,7 @@
     <script src="scripts/liveblog-marketplace/directives/search-panel.js"></script>
     <script src="scripts/liveblog-marketplace/directives/blog-preview-modal.js"></script>
     <script src="scripts/liveblog-marketplace/directives/blogs-list.js"></script>
+    <script src="scripts/liveblog-marketplace/directives/marketplace-switch.js"></script>
     <script src="scripts/liveblog-marketplace/actions/marketplace.js"></script>
     <script src="scripts/liveblog-marketplace/reducers/marketplace.js"></script>
     <!-- endbuild -->

--- a/client/app/scripts/liveblog-edit/views/settings.html
+++ b/client/app/scripts/liveblog-edit/views/settings.html
@@ -137,15 +137,9 @@
 
                             <div lb-syndication-switch></div>
 
-                            <div class="form-group">
-                                <label for="inputTitle" class="control-label" translate>Market</label>
-                                <div class="form-input relative">
-                                    <span class="blog-status">{{ settings.market_enabled ? 'Marketed' : 'Private' | translate }}</span>
-                                    <span style="display: block" tooltip="{{ settings.market_enabled ? 'Keep private' : 'Show in market' | translate }}" tooltip-placement="right">
-                                        <span class="pull-left" sd-switch ng-model="settings.market_enabled" data-blog-status-switch></span>
-                                    </span>
-                                </div>
-                            </div>
+                            <div
+                                lb-marketplace-switch
+                                market-enabled="settings.market_enabled"></div>
 
                             <div class="form-group">
                                 <label for="category" class="control-label" translate>Category</label>

--- a/client/app/scripts/liveblog-marketplace/directives/marketplace-switch.js
+++ b/client/app/scripts/liveblog-marketplace/directives/marketplace-switch.js
@@ -1,9 +1,9 @@
 liveblogMarketplace
-    .directive('lbMarketplaceSwitch', [function() {
+    .directive('lbMarketplaceSwitch', function() {
         return {
             templateUrl: 'scripts/liveblog-marketplace/views/marketplace-switch.html',
             scope: {
                 marketEnabled: '='
             }
         };
-    }]);
+    });

--- a/client/app/scripts/liveblog-marketplace/directives/marketplace-switch.js
+++ b/client/app/scripts/liveblog-marketplace/directives/marketplace-switch.js
@@ -1,0 +1,9 @@
+liveblogMarketplace
+    .directive('lbMarketplaceSwitch', [function() {
+        return {
+            templateUrl: 'scripts/liveblog-marketplace/views/marketplace-switch.html',
+            scope: {
+                marketEnabled: '='
+            }
+        };
+    }]);

--- a/client/app/scripts/liveblog-marketplace/views/marketplace-switch.html
+++ b/client/app/scripts/liveblog-marketplace/views/marketplace-switch.html
@@ -1,18 +1,16 @@
 <div class="form-group">
-<label for="inputTitle" class="control-label" translate>Market</label>
-<div class="form-input relative">
-    <span class="blog-status">{{ marketEnabled ? 'Marketed' : 'Private' | translate }}</span>
-    <span
-        style="display: block"
-        tooltip="{{ marketEnabled ? 'Keep private' : 'Show in market' | translate }}"
-        tooltip-placement="right">
+    <label for="inputTitle" class="control-label" translate>Market</label>
+    <div class="form-input relative">
+        <span class="blog-status">{{ marketEnabled ? 'Marketed' : 'Private' | translate }}</span>
         <span
-            class="pull-left"
-            sd-switch
-            ng-model="marketEnabled"
-            data-blog-status-switch></span>
-    </span>
+            style="display: block"
+            tooltip="{{ marketEnabled ? 'Keep private' : 'Show in market' | translate }}"
+            tooltip-placement="right">
+            <span
+                class="pull-left"
+                sd-switch
+                ng-model="marketEnabled"
+                data-blog-status-switch></span>
+        </span>
+    </div>
 </div>
-</div>
-
-

--- a/client/app/scripts/liveblog-marketplace/views/marketplace-switch.html
+++ b/client/app/scripts/liveblog-marketplace/views/marketplace-switch.html
@@ -1,0 +1,18 @@
+<div class="form-group">
+<label for="inputTitle" class="control-label" translate>Market</label>
+<div class="form-input relative">
+    <span class="blog-status">{{ marketEnabled ? 'Marketed' : 'Private' | translate }}</span>
+    <span
+        style="display: block"
+        tooltip="{{ marketEnabled ? 'Keep private' : 'Show in market' | translate }}"
+        tooltip-placement="right">
+        <span
+            class="pull-left"
+            sd-switch
+            ng-model="marketEnabled"
+            data-blog-status-switch></span>
+    </span>
+</div>
+</div>
+
+


### PR DESCRIPTION
In blog settings, the market switch is now a separate directive belonging to the `liveblog-marketplace` module.

This allows an easy removal of the market switch in case the `liveblog-marketplace` module is deactivated.