### PR TITLE
LBSD-1353 Fix styling issue

### DIFF
--- a/client/app/scripts/liveblog-edit/styles/liveblog-edit.less
+++ b/client/app/scripts/liveblog-edit/styles/liveblog-edit.less
@@ -552,6 +552,8 @@
                                 }
                                 .st-embed-block {
                                     font-size: .9em;
+                                    word-wrap: break-word;
+
                                     &.embed-input {.inline-field();}
                                     &.embed-preview
                                         .noembed-embed {


### PR DESCRIPTION
adding certain type of edge URL breaks the Liveblog UI
Example of such URL is AK%22%20style%3D%22background:url(javascript:alert(%27XSS%27))%22%20OS%22