### PR TITLE
LBSD-1402 Deactivate blog actions when archived

### DIFF
--- a/client/app/scripts/liveblog-edit/directives.js
+++ b/client/app/scripts/liveblog-edit/directives.js
@@ -135,7 +135,8 @@ define([
                             return vm.pagesManager.setAuthors(users.map(function(user) {return user._id;})).then(function() {
                                 vm.isLoading = false;
                             });
-                        }
+                        },
+                        isBlogClosed: $scope.$parent.blog.blog_status == 'closed'
                     });
                     $scope.lbPostsInstance = vm;
                     // retrieve first page

--- a/client/app/scripts/liveblog-edit/views/main.html
+++ b/client/app/scripts/liveblog-edit/views/main.html
@@ -241,7 +241,7 @@
                     <i class="svg-icon-move fix-cancel-move-icon"></i>
                     <button class="btn btn-xs fix-cancel-move-button" translate ng-click="clearTimelineReordering();" tooltip-placement="bottom" tooltip="Cancel and exit reordering mode">Cancel</button>
                 </div>
-                <div class="header--live">
+                <div class="header--live" ng-if="isBlogOpened()">
                     <a href="{{ publicUrl }}" target="_blank" ng-disabled="!publicUrl" translate>Live</a>
                 </div>
                 <div class="header--filters">                                        

--- a/client/app/scripts/liveblog-edit/views/post.html
+++ b/client/app/scripts/liveblog-edit/views/post.html
@@ -32,7 +32,7 @@
                     <div class="inline" ng-if="post.showUpdate">
                         <span class="updated-label" translate>&nbsp;Updated</span> <time class="updated-time">{{ post.content_updated_date | reldate }}</time>
                     </div>
-                    <div class="lb-post__actions">
+                    <div class="lb-post__actions" ng-if="!postsListCtrl.isBlogClosed">
                         <ul>
                             <li ng-if="functionize(postsListCtrl.allowEditing)(post)">
                                 <a ng-click="highlightPost(post)" tooltip-placement="bottom" tooltip="{{ 'Highlight post' | translate }}">


### PR DESCRIPTION
Added the following when viewing an archived blog:

* Deactivate blog actions in the timeline (moved, delete, star...)
* Deactivate the Live link