### PR TITLE
LBSD-1305 When I click on button to "unpublish and save in contributions" by a post in timeline, post does not appear in contributions

### DIFF
--- a/server/liveblog/syndication/__init__.py
+++ b/server/liveblog/syndication/__init__.py
@@ -29,5 +29,5 @@ superdesk.privilege(name='consumers', label='Consumers Management', description=
 superdesk.privilege(name='producers', label='Producers Management', description='User can manage producers')
 superdesk.privilege(name='syndication_out', label='Consumer Syndication Management',
                     description='User can manage consumer syndication.')
-superdesk.privilege(name='syndication_in', label='Producer Syndication Management',
+superdesk.privilege(name='syndication_in_p', label='Producer Syndication Management',
                     description='User can manage producer syndication.')

--- a/server/liveblog/syndication/__init__.py
+++ b/server/liveblog/syndication/__init__.py
@@ -29,5 +29,6 @@ superdesk.privilege(name='consumers', label='Consumers Management', description=
 superdesk.privilege(name='producers', label='Producers Management', description='User can manage producers')
 superdesk.privilege(name='syndication_out', label='Consumer Syndication Management',
                     description='User can manage consumer syndication.')
+# IMPORTANT: the _p is here to prevent a bug when querying non syndicated posts on elasticsearch
 superdesk.privilege(name='syndication_in_p', label='Producer Syndication Management',
                     description='User can manage producer syndication.')

--- a/server/liveblog/syndication/syndication.py
+++ b/server/liveblog/syndication/syndication.py
@@ -226,8 +226,8 @@ class SyndicationIn(Resource):
     }
 
     item_methods = ['GET', 'PATCH', 'PUT', 'DELETE']
-    privileges = {'POST': 'syndication_in', 'PATCH': 'syndication_in', 'PUT': 'syndication_in',
-                  'DELETE': 'syndication_in'}
+    privileges = {'POST': 'syndication_in_p', 'PATCH': 'syndication_in_p', 'PUT': 'syndication_in_p',
+                  'DELETE': 'syndication_in_p'}
     schema = syndication_in_schema
 
 


### PR DESCRIPTION
Change privilege name to sort out this issue.

`syndication_in` was being returned inside elastic search post query as part of the user `active_privileges` object. Therefore querying for an post with a missing `syndication_in` key would not work.