### PR TITLE
preview button hidden for free types and more tooltips

### DIFF
--- a/client/app/scripts/liveblog-edit/views/main.html
+++ b/client/app/scripts/liveblog-edit/views/main.html
@@ -6,10 +6,10 @@
     </div>
     <h3 class="page-nav-title">{{ blog.title }}</h3>
     <div class="button-stack right-stack" ng-if="blogSecurityService.canAccessSettings(blog)">
-        <a class="navbtn analytics-link" ng-href="#/liveblog/analytics/{{::blog._id}}">
+        <a class="navbtn analytics-link" ng-href="#/liveblog/analytics/{{::blog._id}}" title="{{ 'Analytics' | translate }}">
             <i class="svg-icon-analytics"></i>
         </a>
-        <a class="navbtn settings-link" ng-href="#/liveblog/settings/{{::blog._id}}">
+        <a class="navbtn settings-link" ng-href="#/liveblog/settings/{{::blog._id}}" title="{{ 'Settings' | translate }}">
             <i class="svg-icon-settings"></i>
         </a>
     </div>
@@ -148,7 +148,7 @@
                         <div ng-if="!preview">
                         <header>
                             <h4>{{'Editor' | translate}}</h4>
-                            <button class="btn btn-info pull-right" ng-click="togglePreview()" ng-disabled="actionStatus() && !isCurrentPostPublished()" translate>Preview
+                            <button class="btn btn-info pull-right" ng-click="togglePreview()" ng-disabled="actionStatus() && !isCurrentPostPublished()" translate  ng-if="selectedPostType=='Default'">Preview
                             </button>
                             <button class="btn pull-right" ng-click="askAndResetEditor()" translate>Reset</button>
                             <button class="btn pull-right btn--with-icon-right btn--with-label" ng-click="toggleTypePostDialog()">


### PR DESCRIPTION
LBSD-1377
Purpose of the preview button for post types other than default
LBSD-1358
Add "helper texts" to main navigation icons in the blog editor