### PR TITLE
LBSD-1355 Limit maximum upload image size

### DIFF
--- a/client/app/scripts/ng-sir-trevor-blocks.js
+++ b/client/app/scripts/ng-sir-trevor-blocks.js
@@ -518,8 +518,10 @@ define([
                         urlAPI = window.webkitURL;
                     }
 
-                    if ((file.size / 1024 / 1024) > config.maxImgUploadSizeMB) {
-                        var message = "Image bigger than " + config.maxImgUploadSizeMB + "MB";
+                    if (file.size > config.maxContentLength) {
+                        var message = "Image bigger than " +
+                            (config.maxContentLength / 1024 / 1024) +
+                            "MB";
 
                         that.addMessage(message);
                         that.ready();

--- a/client/app/scripts/ng-sir-trevor-blocks.js
+++ b/client/app/scripts/ng-sir-trevor-blocks.js
@@ -517,6 +517,16 @@ define([
                     if (typeof urlAPI === 'undefined') {
                         urlAPI = window.webkitURL;
                     }
+
+                    if ((file.size / 1024 / 1024) > config.maxImgUploadSizeMB) {
+                        var message = "Image bigger than " + config.maxImgUploadSizeMB + "MB";
+
+                        that.addMessage(message);
+                        that.ready();
+
+                        return;
+                    }
+
                     // Handle one upload at a time
                     if (/image/.test(file.type)) {
                         this.loading();

--- a/client/tasks/options/template.js
+++ b/client/tasks/options/template.js
@@ -41,7 +41,7 @@ module.exports = function(grunt) {
                 }
             },
 
-            maxImgUploadSizeMB: process.env.MAX_IMG_UPLOAD_SIZE_MB || 8,
+            maxContentLength: process.env.MAX_CONTENT_LENGTH || 8 * 1024 * 1024,
 
             // default timezone for the app
             defaultTimezone: grunt.option('defaultTimezone') || 'Europe/London',

--- a/client/tasks/options/template.js
+++ b/client/tasks/options/template.js
@@ -41,6 +41,8 @@ module.exports = function(grunt) {
                 }
             },
 
+            maxImgUploadSizeMB: process.env.MAX_IMG_UPLOAD_SIZE_MB || 8,
+
             // default timezone for the app
             defaultTimezone: grunt.option('defaultTimezone') || 'Europe/London',
 


### PR DESCRIPTION
Maximum image upload size can be set via environment variable otherwise defaults to 8MB.