### PR TITLE
hotfix: use `get` method for `syndication_enabled`.

### DIFF
--- a/server/liveblog/blogs/blogs.py
+++ b/server/liveblog/blogs/blogs.py
@@ -258,7 +258,7 @@ class BlogService(BaseService):
     def on_delete(self, doc):
         # Prevent delete of blog if blog has consumers
         out = get_resource_service('syndication_out').find({'blog_id': doc['_id']})
-        if doc['syndication_enabled'] and out.count():
+        if doc.get('syndication_enabled', False) and out.count():
             raise SuperdeskApiError.forbiddenError(message='Cannot delete syndication: blog has active consumers.')
 
         delete_blog_embed_on_s3.delay(doc.get('_id'))

--- a/server/liveblog/syndication/blogs.py
+++ b/server/liveblog/syndication/blogs.py
@@ -70,7 +70,7 @@ def _create_blogs_syndicate(blog_id, consumer_blog_id, auto_retrieve, start_date
     blog = blogs_service.find_one(req=None, checkUser=False, _id=blog_id)
     if blog is None:
         return api_error('No blog available for syndication with given id "{}".'.format(blog_id), 409)
-    if not blog['syndication_enabled']:
+    if not blog.get('syndication_enabled', False):
         return api_error('blog is not enabled for syndication', 409)
 
     consumer = _get_consumer_from_auth()

--- a/server/liveblog/syndication/syndication.py
+++ b/server/liveblog/syndication/syndication.py
@@ -75,7 +75,7 @@ class SyndicationOutService(BaseService):
 
     def get_blog_syndication(self, blog_id):
         blog = self._get_blog(blog_id)
-        if not blog['syndication_enabled']:
+        if not blog.get('syndication_enabled'):
             logger.info('Syndication not enabled for blog "{}"'.format(blog['_id']))
             return []
         else:


### PR DESCRIPTION
dirrect access is causing errors when blogs don't has
`syndication_enabled` property at all.