### PR TITLE
LBSD-1509 Load templates with webpack

### DIFF
--- a/client/Gruntfile.js
+++ b/client/Gruntfile.js
@@ -46,7 +46,6 @@ module.exports = function (grunt) {
         'copy:assets',
         'copy:index',
         'copy:sirTrevor',
-        'ngtemplates:dev',
         'webpack-dev-server:start'
     ]);
 
@@ -66,7 +65,6 @@ module.exports = function (grunt) {
         'copy:assets',
         'copy:index',
         'copy:sirTrevor',
-        'ngtemplates:dev',
         'webpack:build'
     ]);
 

--- a/client/app/scripts/liveblog-analytics/index.js
+++ b/client/app/scripts/liveblog-analytics/index.js
@@ -1,5 +1,7 @@
 import './styles/analytics.scss';
 
+import analiticsListTpl from 'scripts/liveblog-analytics/views/view-list.html';
+
 import liveblogAnalyticsController from './controllers/controller-analytics';
 import lbAnalyticsListCtrl from './directives/directives-analytics';
 
@@ -28,7 +30,7 @@ export default angular
       scope: {
         analytics: '='
       },
-      templateUrl: 'scripts/liveblog-analytics/views/view-list.html',
+      templateUrl: analiticsListTpl,
       controllerAs: 'analyticsList',
       controller: lbAnalyticsListCtrl
     };

--- a/client/app/scripts/liveblog-bloglist/module.js
+++ b/client/app/scripts/liveblog-bloglist/module.js
@@ -1,533 +1,533 @@
-(function() {
-    BlogListController.$inject = ['$scope', '$location', 'api', 'gettext', 'upload',
-        'isArchivedFilterSelected', '$q', 'blogSecurityService', 'notify', 'config'];
-    function BlogListController($scope, $location, api, gettext, upload,
-        isArchivedFilterSelected, $q, blogSecurityService, notify, config) {
-        $scope.maxResults = 25;
-        $scope.states = [
-            {name: 'active', code: 'open', text: gettext('Active blogs')},
-            {name: 'archived', code: 'closed', text: gettext('Archived blogs')}
-        ];
-        $scope.activeState = isArchivedFilterSelected ? $scope.states[1] : $scope.states[0];
-        $scope.creationStep = 'Details';
-        $scope.requestAccessMessage = gettext('Click to request access');
-        $scope.blogMembers = [];
-        $scope.changeState = function(state) {
-            $scope.activeState = state;
-            $location.path('/liveblog/' + state.name);
-            fetchBlogs();
-        };
-        $scope.modalActive = false;
+import mainTemplate from 'scripts/liveblog-bloglist/views/main.html';
 
-        $scope.mailto = 'mailto:upgrade@liveblog.pro?subject='+
-            encodeURIComponent(location.hostname) +
-            ' ' +
-            config.subscriptionLevel;
-
-        function clearCreateBlogForm() {
-            $scope.preview = {};
-            $scope.progress = {width: 0};
-            $scope.newBlog = {
-                title: '',
-                description: ''
-            };
-            $scope.newBlogError = '';
-            $scope.creationStep = 'Details';
-            $scope.blogMembers = [];
-        }
-        clearCreateBlogForm();
-        $scope.isAdmin = blogSecurityService.isAdmin;
-        $scope.isUserAllowedToCreateABlog = blogSecurityService.canCreateABlog;
-        $scope.isUserAllowedToOpenBlog = blogSecurityService.canAccessBlog;
-        // blog list embed code.
-        function fetchBloglistEmbed() {
-            var criteria = {source: {
-                query: {filtered: {filter: {term: {key: 'blogslist'}}}}
-            }};
-            api.blogslist.query(criteria, false).then(function(embed) {
-                var url;
-                if (embed._items.length) {
-                    url = embed._items[0].value;
-                } else if (config.debug) {
-                    url = 'http://localhost:5000/blogslist_embed'
-                }
-                if (url) {
-                    $scope.bloglistEmbed = '<iframe id="liveblog-bloglist" width="100%" ' +
-                        'scrolling="no" src="' + url + '" frameborder="0" allowfullscreen></iframe>';
-                }
-            });
-        }
-        $scope.cancelEmbed = function() {
-            $scope.embedModal = false;
-        };
-        $scope.openEmbed = function() {
-            fetchBloglistEmbed()
-            $scope.embedModal = true;
-        };
-
-        $scope.cancelCreate = function() {
-            clearCreateBlogForm();
-            $scope.newBlogModalActive = false;
-        };
-
-        $scope.cancelUpgrade = function() {
-            $scope.embedUpgrade = false;
-        };
-
-        $scope.openNewBlog = function() {
-            blogSecurityService
-                .showUpgradeModal()
-                .then(function(showUpgradeModal) {
-                    if (showUpgradeModal)
-                        $scope.embedUpgrade = true;
-                    else
-                        $scope.newBlogModalActive = true;
-                });
-        };
-
-        $scope.creationInProcess = false;
-
-        $scope.createBlog = function() {
-            $scope.creationInProcess = true;
-
-            var members = _.map($scope.blogMembers, function(obj) {
-                return {user: obj._id};
-            });
-            //upload image only if we have a valid one chosen
-            var promise = $scope.preview.url ? $scope.upload($scope.preview) : $q.when();
-            return promise.then(function() {
-                return api.blogs.save({
-                    title: $scope.newBlog.title,
-                    description: $scope.newBlog.description,
-                    picture_url: $scope.newBlog.picture_url,
-                    picture: $scope.newBlog.picture,
-                    members: members
-                }).then(function(blog) {
-                    $scope.creationInProcess = false;
-                    $scope.edit(blog);
-                }, function(error) {
-                    $scope.creationInProcess = false;
-                    //error handler
-                    $scope.newBlogError = gettext('Something went wrong. Please try again later');
-                });
-            });
-        };
-
-        $scope.upload = function(config) {
-            var form = {};
-            if (config.img) {
-                form.media = config.img;
-            } else if (config.url) {
-                form.URL = config.url;
-            } else {
-                return;
-            }
-            // return a promise of upload which will call the success/error callback
-            return api.archive.getUrl().then(function(url) {
-                return upload.start({
-                    method: 'POST',
-                    url: url,
-                    data: form
-                })
-                .then(function(response) {
-                    if (response.data._status === 'ERR'){
-                        return;
-                    }
-                    var picture_url = response.data.renditions.viewImage.href;
-                    $scope.newBlog.picture_url = picture_url;
-                    $scope.newBlog.picture = response.data._id;
-                }, function(error) {
-                    notify.error(
-                        (error.statusText !== '') ? error.statusText : gettext('There was a problem with your upload')
-                    );
-                }, function(progress) {
-                    $scope.progress.width = Math.round(progress.loaded / progress.total * 100.0);
-                });
-            });
-        };
-
-        $scope.remove = function(blog) {
-            _.remove($scope.blogs._items, blog);
-        };
-
-        $scope.edit = function(blog) {
-            $location.path('/liveblog/edit/' + blog._id);
-        };
-
-        $scope.openAccessRequest = function(blog) {
-            $scope.accessRequestedTo = blog;
-            $scope.showBlogAccessModal = true;
-        }
-
-        $scope.closeAccessRequest = function() {
-            $scope.accessRequestedTo = false;
-            $scope.showBlogAccessModal = false;
-        };
-
-        $scope.requestAccess = function(blog) {
-
-            var showRequestDialog = true;
-            //check to see if the current user hasn't been accepted during this session (before refreshing)
-            if (blog.members) {
-                _.each(blog.members, function(member) {
-                    if (member.user === $scope.$root.currentUser._id) {
-                        showRequestDialog = false;
-                    }
-                });
-            }
-
-            if (showRequestDialog) {
-                notify.info(gettext('Sending request'));
-                api('request_membership').save({blog: blog._id}).then(
-                    function(data) {
-                        notify.pop();
-                        notify.info(gettext('Request sent'));
-                    },
-                    function(data) {
-                        notify.pop();
-                        var message = gettext('Something went wrong, plase try again later!');
-                        if (data.data._message === 'A request has already been sent') {
-                            message = gettext('A request has already been sent');
-                        }
-                        notify.error(message, 5000);
-                    }
-                );
-                $scope.closeAccessRequest();
-            } else {
-                notify.pop();
-                notify.error(gettext('You are already member of this blog\'s team'));
-            }
-        };
-
-        $scope.switchTab = function(newTab) {
-            $scope.creationStep = newTab;
-        };
-
-        $scope.handleKeyDown = function(event, action) {
-            //prevent form submission and editor 'artifact'
-            if (event.keyCode === 13) {
-                event.preventDefault();
-                switch (action) {
-                    case 'goToTeamTab':
-                        //we need at least a valid title from the first tab
-                        if ($scope.newBlog.title) {
-                            $scope.switchTab('Team');
-                        }
-                        break;
-                }
-            }
-        };
-
-        $scope.addMember = function(user) {
-            $scope.blogMembers.push(user);
-        };
-
-        $scope.removeMember = function(user) {
-            $scope.blogMembers.splice($scope.blogMembers.indexOf(user), 1);
-        };
-
-        $scope.hasReachedMembersLimit = function() {
-            if (!config.assignableUsers.hasOwnProperty(config.subscriptionLevel))
-            return false;
-
-            return $scope.blogMembers.length >= config.assignableUsers[config.subscriptionLevel];
-        };
-
-        //set grid or list view
-        $scope.setBlogsView = function(blogsView) {
-            if (typeof blogsView !== 'undefined') {
-                $scope.blogsView = blogsView;
-                localStorage.setItem('blogsView', blogsView);
-            } else if (typeof (localStorage.getItem('blogsView')) === 'undefined'
-                || (localStorage.getItem('blogsView')) === null) {
-                $scope.blogsView = 'grid';
-            } else {
-                $scope.blogsView = localStorage.getItem('blogsView');
-            }
-        };
-        $scope.setBlogsView();
-
-        function getCriteria() {
-            var params = $location.search(),
-                criteria = {
-                    max_results: $scope.maxResults,
-                    embedded: {'original_creator': 1},
-                    sort: '[("versioncreated", -1)]',
-                    source: {
-                        query: {filtered: {filter: {term: {blog_status: $scope.activeState.code}}}}
-                    }
-                };
-            if (params.q) {
-                criteria.source.query.filtered.query = {
-                    query_string: {
-                        query: '*' + params.q + '*',
-                        fields: ['title', 'description']
-                    }
-                };
-            }
-            if (params.page) {
-                criteria.page = parseInt(params.page, 10);
-            }
-            return criteria;
-        }
-
-        function fetchBlogs() {
-            $scope.blogsLoading = true;
-            api.blogs.query(getCriteria(), false).then(function(blogs) {
-                $scope.blogs = blogs;
-                blogs._items.forEach(function(blog) {
-                    var criteria = {
-                        source: {
-                            query: {
-                                filtered: {filter: {and: [
-                                    {term: {'post_status': 'open'}}, {term: {'blog': blog._id}}
-                                ]}}
-                            }, sort: [{'published_date': 'asc'}]}
-                    };
-                    api.posts.query(criteria).then(function(data) {
-                    blog.posts_count = data._meta.total;
-                    var posts = data._items;
-                    posts.forEach(function(post) {
-                        blog.last_posted = post.published_date;
-                        });
-                    });
-                });
-                $scope.blogsLoading = false;
-            });
-        }
-        // initialize bloglist embed code.
-        fetchBloglistEmbed();
-        // initialize blogs list
+BlogListController.$inject = ['$scope', '$location', 'api', 'gettext', 'upload',
+    'isArchivedFilterSelected', '$q', 'blogSecurityService', 'notify', 'config'];
+function BlogListController($scope, $location, api, gettext, upload,
+    isArchivedFilterSelected, $q, blogSecurityService, notify, config) {
+    $scope.maxResults = 25;
+    $scope.states = [
+        {name: 'active', code: 'open', text: gettext('Active blogs')},
+        {name: 'archived', code: 'closed', text: gettext('Archived blogs')}
+    ];
+    $scope.activeState = isArchivedFilterSelected ? $scope.states[1] : $scope.states[0];
+    $scope.creationStep = 'Details';
+    $scope.requestAccessMessage = gettext('Click to request access');
+    $scope.blogMembers = [];
+    $scope.changeState = function(state) {
+        $scope.activeState = state;
+        $location.path('/liveblog/' + state.name);
         fetchBlogs();
-        // fetch when maxResults is updated from the searchbar-directive
-        $scope.$watch('maxResults', fetchBlogs);
-        // fetch when criteria are updated from url (searchbar-directive)
-        $scope.$on('$routeUpdate', fetchBlogs);
+    };
+    $scope.modalActive = false;
+
+    $scope.mailto = 'mailto:upgrade@liveblog.pro?subject='+
+        encodeURIComponent(location.hostname) +
+        ' ' +
+        config.subscriptionLevel;
+
+    function clearCreateBlogForm() {
+        $scope.preview = {};
+        $scope.progress = {width: 0};
+        $scope.newBlog = {
+            title: '',
+            description: ''
+        };
+        $scope.newBlogError = '';
+        $scope.creationStep = 'Details';
+        $scope.blogMembers = [];
+    }
+    clearCreateBlogForm();
+    $scope.isAdmin = blogSecurityService.isAdmin;
+    $scope.isUserAllowedToCreateABlog = blogSecurityService.canCreateABlog;
+    $scope.isUserAllowedToOpenBlog = blogSecurityService.canAccessBlog;
+    // blog list embed code.
+    function fetchBloglistEmbed() {
+        var criteria = {source: {
+            query: {filtered: {filter: {term: {key: 'blogslist'}}}}
+        }};
+        api.blogslist.query(criteria, false).then(function(embed) {
+            var url;
+            if (embed._items.length) {
+                url = embed._items[0].value;
+            } else if (config.debug) {
+                url = 'http://localhost:5000/blogslist_embed'
+            }
+            if (url) {
+                $scope.bloglistEmbed = '<iframe id="liveblog-bloglist" width="100%" ' +
+                    'scrolling="no" src="' + url + '" frameborder="0" allowfullscreen></iframe>';
+            }
+        });
+    }
+    $scope.cancelEmbed = function() {
+        $scope.embedModal = false;
+    };
+    $scope.openEmbed = function() {
+        fetchBloglistEmbed()
+        $scope.embedModal = true;
+    };
+
+    $scope.cancelCreate = function() {
+        clearCreateBlogForm();
+        $scope.newBlogModalActive = false;
+    };
+
+    $scope.cancelUpgrade = function() {
+        $scope.embedUpgrade = false;
+    };
+
+    $scope.openNewBlog = function() {
+        blogSecurityService
+            .showUpgradeModal()
+            .then(function(showUpgradeModal) {
+                if (showUpgradeModal)
+                    $scope.embedUpgrade = true;
+                else
+                    $scope.newBlogModalActive = true;
+            });
+    };
+
+    $scope.creationInProcess = false;
+
+    $scope.createBlog = function() {
+        $scope.creationInProcess = true;
+
+        var members = _.map($scope.blogMembers, function(obj) {
+            return {user: obj._id};
+        });
+        //upload image only if we have a valid one chosen
+        var promise = $scope.preview.url ? $scope.upload($scope.preview) : $q.when();
+        return promise.then(function() {
+            return api.blogs.save({
+                title: $scope.newBlog.title,
+                description: $scope.newBlog.description,
+                picture_url: $scope.newBlog.picture_url,
+                picture: $scope.newBlog.picture,
+                members: members
+            }).then(function(blog) {
+                $scope.creationInProcess = false;
+                $scope.edit(blog);
+            }, function(error) {
+                $scope.creationInProcess = false;
+                //error handler
+                $scope.newBlogError = gettext('Something went wrong. Please try again later');
+            });
+        });
+    };
+
+    $scope.upload = function(config) {
+        var form = {};
+        if (config.img) {
+            form.media = config.img;
+        } else if (config.url) {
+            form.URL = config.url;
+        } else {
+            return;
+        }
+        // return a promise of upload which will call the success/error callback
+        return api.archive.getUrl().then(function(url) {
+            return upload.start({
+                method: 'POST',
+                url: url,
+                data: form
+            })
+            .then(function(response) {
+                if (response.data._status === 'ERR'){
+                    return;
+                }
+                var picture_url = response.data.renditions.viewImage.href;
+                $scope.newBlog.picture_url = picture_url;
+                $scope.newBlog.picture = response.data._id;
+            }, function(error) {
+                notify.error(
+                    (error.statusText !== '') ? error.statusText : gettext('There was a problem with your upload')
+                );
+            }, function(progress) {
+                $scope.progress.width = Math.round(progress.loaded / progress.total * 100.0);
+            });
+        });
+    };
+
+    $scope.remove = function(blog) {
+        _.remove($scope.blogs._items, blog);
+    };
+
+    $scope.edit = function(blog) {
+        $location.path('/liveblog/edit/' + blog._id);
+    };
+
+    $scope.openAccessRequest = function(blog) {
+        $scope.accessRequestedTo = blog;
+        $scope.showBlogAccessModal = true;
     }
 
-    var app = angular.module('liveblog.bloglist', ['liveblog.security']);
-    app.config(['apiProvider', function(apiProvider) {
-        apiProvider.api('blogslist', {
-            type: 'http',
-            backend: {rel: 'blogslist'}
-        });
-        apiProvider.api('blogs', {
-            type: 'http',
-            backend: {rel: 'blogs'}
-        });
-        apiProvider.api('archive', {
-            type: 'http',
-            backend: {rel: 'archive'}
-        });
-    }]).config(['superdeskProvider', function(superdesk) {
-        superdesk
-            .activity('/liveblog', {
-                label: gettext('Blog List'),
-                controller: BlogListController,
-                templateUrl: 'scripts/liveblog-bloglist/views/main.html',
-                category: superdesk.MENU_MAIN,
-                adminTools: false,
-                resolve: {isArchivedFilterSelected: function() {return false;}}
-            }).activity('/liveblog/active', {
-                label: gettext('Blog List'),
-                controller: BlogListController,
-                templateUrl: 'scripts/liveblog-bloglist/views/main.html',
-                resolve: {isArchivedFilterSelected: function() {return false;}}
-            }).activity('/liveblog/archived', {
-                label: gettext('Blog List'),
-                controller: BlogListController,
-                templateUrl: 'scripts/liveblog-bloglist/views/main.html',
-                resolve: {isArchivedFilterSelected: function() {return true;}}
-            });
-    }]);
-    app.filter('htmlToPlaintext', function() {
-        return function(text) {
-            //replace paragraph and list item with an empty space
-            var retValue = text ? String(text).replace(/<(p|li)>/g, ' ') : '';
-            retValue = retValue.replace(/<[^>]+>/gm, '');
-            return retValue.replace(/(&nbsp;)/gm, '');
-        };
-      }
-    );
-    app.filter('username', ['session', function usernameFilter(session) {
-        return function getUsername(user) {
-            return user ? user.display_name || user.username : null;
-        };
-    }]);
-    app.directive('sdPlainImage', ['gettext', 'notify', 'config', function(gettext, notify, config) {
-        return {
-            scope: {
-                src: '=',
-                file: '=',
-                progressWidth: '=',
-                minWidth: '@',
-                minHeight: '@'
-            },
-            link: function(scope, elem) {
-                scope.$watch('src', function(src) {
-                    elem.empty();
-                    if (src) {
-                        var img = new Image();
-                        if (scope.file.size > config.maxContentLength) {
-                            notify.error(gettext(
-                                "Blog image is bigger than " + (config.maxContentLength / 1024 / 1024) + "MB"
-                            ));
-                            scope.src = null;
-                            scope.progressWidth = 0;
-                        } else {
-                            if ((scope.file.size / 1048576) > 2) {
-                                notify.info(gettext('Blog image is big, upload can take some time!'));
-                            }
-                            img.onload = function() {
-                                scope.progressWidth = 80;
+    $scope.closeAccessRequest = function() {
+        $scope.accessRequestedTo = false;
+        $scope.showBlogAccessModal = false;
+    };
 
-                                var minWidth = scope.minWidth || 320,
-                                    minHeight = scope.minHeight || 240;
-                                if (this.width < minWidth || this.height < minHeight) {
-                                    scope.$apply(function() {
-                                        notify.error(gettext(
-                                            'Sorry, but blog image must be at least ' + minWidth + 'x' +
-                                            minHeight + ' pixels big!'
-                                        ));
-                                        scope.file = null;
-                                        scope.src = null;
-                                        scope.progressWidth = 0;
-                                    });
+    $scope.requestAccess = function(blog) {
 
-                                    return;
-                                }
-                                elem.append(img);
-                                scope.$apply(function() {
-                                    scope.progressWidth = 0;
-                                });
-                            };
-                            img.src = src;
-                        }
-                    }
-                });
-            }
-        };
-    }]).directive('ifBackgroundImage', function() {
-        return {
-            restrict: 'A',
-            scope: {
-                ifBackgroundImage: '@'
-            },
-            link: function(scope, element, attrs) {
-                var url = scope.ifBackgroundImage;
-                if (url) {
-                    element.css({
-                        'background-image': 'url(' + url + ')'
-                    });
+        var showRequestDialog = true;
+        //check to see if the current user hasn't been accepted during this session (before refreshing)
+        if (blog.members) {
+            _.each(blog.members, function(member) {
+                if (member.user === $scope.$root.currentUser._id) {
+                    showRequestDialog = false;
                 }
-            }
-        };
-    })
-    .directive('lbUserSelectList', ['api', function(api) {
-            return {
-                scope: {
-                    members: '=',
-                    onchoose: '&'
+            });
+        }
+
+        if (showRequestDialog) {
+            notify.info(gettext('Sending request'));
+            api('request_membership').save({blog: blog._id}).then(
+                function(data) {
+                    notify.pop();
+                    notify.info(gettext('Request sent'));
                 },
-                templateUrl: 'scripts/apps/desks/views/user-select.html',
-                link: function(scope, elem, attrs) {
-
-                    var ARROW_UP = 38, ARROW_DOWN = 40, ENTER = 13;
-
-                    scope.selected = null;
-                    scope.search = null;
-                    scope.users = {};
-
-                    var _refresh = function() {
-                        scope.users = {};
-                        return api('users').query({where: JSON.stringify({
-                            '$or': [
-                                {username: {'$regex': scope.search, '$options': '-i'}},
-                                {first_name: {'$regex': scope.search, '$options': '-i'}},
-                                {last_name: {'$regex': scope.search, '$options': '-i'}},
-                                {email: {'$regex': scope.search, '$options': '-i'}}
-                            ]
-                        })})
-                        .then(function(result) {
-                            scope.users = result;
-                            scope.users._items = _.filter(scope.users._items, function(item) {
-                                var found = false;
-                                _.each(scope.members, function(member) {
-                                    if (member._id === item._id) {
-                                        found = true;
-                                    }
-                                });
-                                return !found;
-                            });
-                            scope.selected = null;
-                        });
-                    };
-                    var refresh = _.debounce(_refresh, 1000);
-
-                    scope.$watch('search', function() {
-                        if (scope.search) {
-                            refresh();
-                        }
-                    });
-
-                    function getSelectedIndex() {
-                        if (scope.selected) {
-                            var selectedIndex = -1;
-                            _.each(scope.users._items, function(item, index) {
-                                if (item === scope.selected) {
-                                    selectedIndex = index;
-                                }
-                            });
-                            return selectedIndex;
-                        } else {
-                            return -1;
-                        }
+                function(data) {
+                    notify.pop();
+                    var message = gettext('Something went wrong, plase try again later!');
+                    if (data.data._message === 'A request has already been sent') {
+                        message = gettext('A request has already been sent');
                     }
+                    notify.error(message, 5000);
+                }
+            );
+            $scope.closeAccessRequest();
+        } else {
+            notify.pop();
+            notify.error(gettext('You are already member of this blog\'s team'));
+        }
+    };
 
-                    function previous() {
-                        var selectedIndex = getSelectedIndex(),
-                        previousIndex = _.max([0, selectedIndex - 1]);
-                        if (selectedIndex > 0) {
-                            scope.select(scope.users._items[previousIndex]);
-                        }
+    $scope.switchTab = function(newTab) {
+        $scope.creationStep = newTab;
+    };
+
+    $scope.handleKeyDown = function(event, action) {
+        //prevent form submission and editor 'artifact'
+        if (event.keyCode === 13) {
+            event.preventDefault();
+            switch (action) {
+                case 'goToTeamTab':
+                    //we need at least a valid title from the first tab
+                    if ($scope.newBlog.title) {
+                        $scope.switchTab('Team');
                     }
+                    break;
+            }
+        }
+    };
 
-                    function next() {
-                        var selectedIndex = getSelectedIndex(),
-                        nextIndex = _.min([scope.users._items.length - 1, selectedIndex + 1]);
-                        scope.select(scope.users._items[nextIndex]);
-                    }
+    $scope.addMember = function(user) {
+        $scope.blogMembers.push(user);
+    };
 
-                    elem.bind('keydown keypress', function(event) {
-                        scope.$apply(function() {
-                            switch (event.which) {
-                                case ARROW_UP:
-                                    event.preventDefault();
-                                    previous();
-                                    break;
-                                case ARROW_DOWN:
-                                    event.preventDefault();
-                                    next();
-                                    break;
-                                case ENTER:
-                                    event.preventDefault();
-                                    if (getSelectedIndex() >= 0) {
-                                        scope.choose(scope.selected);
-                                    }
-                                    break;
-                            }
-                        });
-                    });
+    $scope.removeMember = function(user) {
+        $scope.blogMembers.splice($scope.blogMembers.indexOf(user), 1);
+    };
 
-                    scope.choose = function(user) {
-                        scope.onchoose({user: user});
-                        scope.search = null;
-                    };
+    $scope.hasReachedMembersLimit = function() {
+        if (!config.assignableUsers.hasOwnProperty(config.subscriptionLevel))
+        return false;
 
-                    scope.select = function(user) {
-                        scope.selected = user;
-                    };
+        return $scope.blogMembers.length >= config.assignableUsers[config.subscriptionLevel];
+    };
+
+    //set grid or list view
+    $scope.setBlogsView = function(blogsView) {
+        if (typeof blogsView !== 'undefined') {
+            $scope.blogsView = blogsView;
+            localStorage.setItem('blogsView', blogsView);
+        } else if (typeof (localStorage.getItem('blogsView')) === 'undefined'
+            || (localStorage.getItem('blogsView')) === null) {
+            $scope.blogsView = 'grid';
+        } else {
+            $scope.blogsView = localStorage.getItem('blogsView');
+        }
+    };
+    $scope.setBlogsView();
+
+    function getCriteria() {
+        var params = $location.search(),
+            criteria = {
+                max_results: $scope.maxResults,
+                embedded: {'original_creator': 1},
+                sort: '[("versioncreated", -1)]',
+                source: {
+                    query: {filtered: {filter: {term: {blog_status: $scope.activeState.code}}}}
                 }
             };
-        }]);
-})();
+        if (params.q) {
+            criteria.source.query.filtered.query = {
+                query_string: {
+                    query: '*' + params.q + '*',
+                    fields: ['title', 'description']
+                }
+            };
+        }
+        if (params.page) {
+            criteria.page = parseInt(params.page, 10);
+        }
+        return criteria;
+    }
+
+    function fetchBlogs() {
+        $scope.blogsLoading = true;
+        api.blogs.query(getCriteria(), false).then(function(blogs) {
+            $scope.blogs = blogs;
+            blogs._items.forEach(function(blog) {
+                var criteria = {
+                    source: {
+                        query: {
+                            filtered: {filter: {and: [
+                                {term: {'post_status': 'open'}}, {term: {'blog': blog._id}}
+                            ]}}
+                        }, sort: [{'published_date': 'asc'}]}
+                };
+                api.posts.query(criteria).then(function(data) {
+                blog.posts_count = data._meta.total;
+                var posts = data._items;
+                posts.forEach(function(post) {
+                    blog.last_posted = post.published_date;
+                    });
+                });
+            });
+            $scope.blogsLoading = false;
+        });
+    }
+    // initialize bloglist embed code.
+    fetchBloglistEmbed();
+    // initialize blogs list
+    fetchBlogs();
+    // fetch when maxResults is updated from the searchbar-directive
+    $scope.$watch('maxResults', fetchBlogs);
+    // fetch when criteria are updated from url (searchbar-directive)
+    $scope.$on('$routeUpdate', fetchBlogs);
+}
+
+var app = angular.module('liveblog.bloglist', ['liveblog.security']);
+app.config(['apiProvider', function(apiProvider) {
+    apiProvider.api('blogslist', {
+        type: 'http',
+        backend: {rel: 'blogslist'}
+    });
+    apiProvider.api('blogs', {
+        type: 'http',
+        backend: {rel: 'blogs'}
+    });
+    apiProvider.api('archive', {
+        type: 'http',
+        backend: {rel: 'archive'}
+    });
+}]).config(['superdeskProvider', function(superdesk) {
+    superdesk
+        .activity('/liveblog', {
+            label: gettext('Blog List'),
+            controller: BlogListController,
+            templateUrl: mainTemplate,
+            category: superdesk.MENU_MAIN,
+            adminTools: false,
+            resolve: {isArchivedFilterSelected: function() {return false;}}
+        }).activity('/liveblog/active', {
+            label: gettext('Blog List'),
+            controller: BlogListController,
+            templateUrl: mainTemplate,
+            resolve: {isArchivedFilterSelected: function() {return false;}}
+        }).activity('/liveblog/archived', {
+            label: gettext('Blog List'),
+            controller: BlogListController,
+            templateUrl: mainTemplate,
+            resolve: {isArchivedFilterSelected: function() {return true;}}
+        });
+}]);
+app.filter('htmlToPlaintext', function() {
+    return function(text) {
+        //replace paragraph and list item with an empty space
+        var retValue = text ? String(text).replace(/<(p|li)>/g, ' ') : '';
+        retValue = retValue.replace(/<[^>]+>/gm, '');
+        return retValue.replace(/(&nbsp;)/gm, '');
+    };
+  }
+);
+app.filter('username', ['session', function usernameFilter(session) {
+    return function getUsername(user) {
+        return user ? user.display_name || user.username : null;
+    };
+}]);
+app.directive('sdPlainImage', ['gettext', 'notify', 'config', function(gettext, notify, config) {
+    return {
+        scope: {
+            src: '=',
+            file: '=',
+            progressWidth: '=',
+            minWidth: '@',
+            minHeight: '@'
+        },
+        link: function(scope, elem) {
+            scope.$watch('src', function(src) {
+                elem.empty();
+                if (src) {
+                    var img = new Image();
+                    if (scope.file.size > config.maxContentLength) {
+                        notify.error(gettext(
+                            "Blog image is bigger than " + (config.maxContentLength / 1024 / 1024) + "MB"
+                        ));
+                        scope.src = null;
+                        scope.progressWidth = 0;
+                    } else {
+                        if ((scope.file.size / 1048576) > 2) {
+                            notify.info(gettext('Blog image is big, upload can take some time!'));
+                        }
+                        img.onload = function() {
+                            scope.progressWidth = 80;
+
+                            var minWidth = scope.minWidth || 320,
+                                minHeight = scope.minHeight || 240;
+                            if (this.width < minWidth || this.height < minHeight) {
+                                scope.$apply(function() {
+                                    notify.error(gettext(
+                                        'Sorry, but blog image must be at least ' + minWidth + 'x' +
+                                        minHeight + ' pixels big!'
+                                    ));
+                                    scope.file = null;
+                                    scope.src = null;
+                                    scope.progressWidth = 0;
+                                });
+
+                                return;
+                            }
+                            elem.append(img);
+                            scope.$apply(function() {
+                                scope.progressWidth = 0;
+                            });
+                        };
+                        img.src = src;
+                    }
+                }
+            });
+        }
+    };
+}]).directive('ifBackgroundImage', function() {
+    return {
+        restrict: 'A',
+        scope: {
+            ifBackgroundImage: '@'
+        },
+        link: function(scope, element, attrs) {
+            var url = scope.ifBackgroundImage;
+            if (url) {
+                element.css({
+                    'background-image': 'url(' + url + ')'
+                });
+            }
+        }
+    };
+})
+.directive('lbUserSelectList', ['api', function(api) {
+    return {
+        scope: {
+            members: '=',
+            onchoose: '&'
+        },
+        templateUrl: 'scripts/apps/desks/views/user-select.html',
+        link: function(scope, elem, attrs) {
+
+            var ARROW_UP = 38, ARROW_DOWN = 40, ENTER = 13;
+
+            scope.selected = null;
+            scope.search = null;
+            scope.users = {};
+
+            var _refresh = function() {
+                scope.users = {};
+                return api('users').query({where: JSON.stringify({
+                    '$or': [
+                        {username: {'$regex': scope.search, '$options': '-i'}},
+                        {first_name: {'$regex': scope.search, '$options': '-i'}},
+                        {last_name: {'$regex': scope.search, '$options': '-i'}},
+                        {email: {'$regex': scope.search, '$options': '-i'}}
+                    ]
+                })})
+                .then(function(result) {
+                    scope.users = result;
+                    scope.users._items = _.filter(scope.users._items, function(item) {
+                        var found = false;
+                        _.each(scope.members, function(member) {
+                            if (member._id === item._id) {
+                                found = true;
+                            }
+                        });
+                        return !found;
+                    });
+                    scope.selected = null;
+                });
+            };
+            var refresh = _.debounce(_refresh, 1000);
+
+            scope.$watch('search', function() {
+                if (scope.search) {
+                    refresh();
+                }
+            });
+
+            function getSelectedIndex() {
+                if (scope.selected) {
+                    var selectedIndex = -1;
+                    _.each(scope.users._items, function(item, index) {
+                        if (item === scope.selected) {
+                            selectedIndex = index;
+                        }
+                    });
+                    return selectedIndex;
+                } else {
+                    return -1;
+                }
+            }
+
+            function previous() {
+                var selectedIndex = getSelectedIndex(),
+                previousIndex = _.max([0, selectedIndex - 1]);
+                if (selectedIndex > 0) {
+                    scope.select(scope.users._items[previousIndex]);
+                }
+            }
+
+            function next() {
+                var selectedIndex = getSelectedIndex(),
+                nextIndex = _.min([scope.users._items.length - 1, selectedIndex + 1]);
+                scope.select(scope.users._items[nextIndex]);
+            }
+
+            elem.bind('keydown keypress', function(event) {
+                scope.$apply(function() {
+                    switch (event.which) {
+                        case ARROW_UP:
+                            event.preventDefault();
+                            previous();
+                            break;
+                        case ARROW_DOWN:
+                            event.preventDefault();
+                            next();
+                            break;
+                        case ENTER:
+                            event.preventDefault();
+                            if (getSelectedIndex() >= 0) {
+                                scope.choose(scope.selected);
+                            }
+                            break;
+                    }
+                });
+            });
+
+            scope.choose = function(user) {
+                scope.onchoose({user: user});
+                scope.search = null;
+            };
+
+            scope.select = function(user) {
+                scope.selected = user;
+            };
+        }
+    };
+}]);

--- a/client/app/scripts/liveblog-edit/controllers/blog-edit.js
+++ b/client/app/scripts/liveblog-edit/controllers/blog-edit.js
@@ -11,6 +11,10 @@
 import angular from 'angular';
 import _ from 'lodash';
 
+import scorecardsTpl from 'scripts/liveblog-edit/views/scorecards.html';
+import adsLocalTpl from 'scripts/liveblog-edit/views/ads-local.html';
+import adsRemoteTpl from 'scripts/liveblog-edit/views/ads-remote.html'
+
 import './../../ng-sir-trevor';
 import './../../ng-sir-trevor-blocks';
 import './../unread.posts.service';
@@ -159,26 +163,20 @@ var BlogEditController = function (api, $q, $scope, blog, notify, gettext, sessi
             return data._items;
         });
 
-        var scorecards = $http.get('scripts/liveblog-edit/views/scorecards.html').then(function(template) {
-            return {
-                name: 'Scorecard',
-                template: template.data
-            };
-        });
+        var scorecards = {
+            name: 'Scorecard',
+            template: $templateCache.get(scorecardsTpl)
+        };
 
-        var adLocal = $http.get('scripts/liveblog-edit/views/ads-local.html').then(function(template) {
-            return {
-                name: 'Advertisment Local',
-                template: template.data
-            };
-        });
+        var adLocal = {
+            name: 'Advertisment Local',
+            template: $templateCache.get(adsLocalTpl)
+        };
 
-        var adRemote = $http.get('scripts/liveblog-edit/views/ads-remote.html').then(function(template) {
-            return {
-                name: 'Advertisment Remote',
-                template: template.data
-            };
-        });
+        var adRemote = {
+            name: 'Advertisment Remote',
+            template: $templateCache.get(adsRemoteTpl)
+        };
 
         $q.all([userFt, adLocal, adRemote, scorecards]).then(function(freetypes) {
             angular.forEach(freetypes, function(freetype) {

--- a/client/app/scripts/liveblog-edit/directives/filter-by-member.js
+++ b/client/app/scripts/liveblog-edit/directives/filter-by-member.js
@@ -1,3 +1,5 @@
+import filterByMemberTpl from 'scripts/liveblog-edit/views/filter-by-member.html';
+
 lbFilterByMember.$inject = ['api'];
 
 export default function lbFilterByMember(api) {
@@ -7,7 +9,7 @@ export default function lbFilterByMember(api) {
             blogId: '=',
             onFilterChange: '='
         },
-        templateUrl: 'scripts/liveblog-edit/views/filter-by-member.html',
+        templateUrl: filterByMemberTpl,
         controllerAs: 'vm',
         controller: ['$scope', function($scope) {
             var vm = this;

--- a/client/app/scripts/liveblog-edit/directives/freetype-image.js
+++ b/client/app/scripts/liveblog-edit/directives/freetype-image.js
@@ -1,9 +1,11 @@
+import freetypeImageTpl from 'scripts/liveblog-edit/views/freetype-image.html';
+
 freetypeImage.$inject = ['$compile', 'modal', 'api', 'upload'];
 
 export default function freetypeImage($compile, modal, api, upload) {
     return {
         restrict: 'E',
-        templateUrl: 'scripts/liveblog-edit/views/freetype-image.html',
+        templateUrl: freetypeImageTpl,
         controller: ['$scope', function($scope) {
             $scope.valid = true;
             $scope._id = _.uniqueId('image');

--- a/client/app/scripts/liveblog-edit/directives/freetype-link.js
+++ b/client/app/scripts/liveblog-edit/directives/freetype-link.js
@@ -1,7 +1,9 @@
+import freetypeLinkTpl from 'scripts/liveblog-edit/views/freetype-link.html';
+
 export default function freetypeLink() {
     return {
         restrict: 'E',
-        templateUrl: 'scripts/liveblog-edit/views/freetype-link.html',
+        templateUrl: freetypeLinkTpl,
         controller: ['$scope', function($scope) {
             var regex = /https?:\/\/[^\s]+\.[^\s\.]+/;
             $scope._id = _.uniqueId('link');

--- a/client/app/scripts/liveblog-edit/directives/freetype-text.js
+++ b/client/app/scripts/liveblog-edit/directives/freetype-text.js
@@ -1,7 +1,9 @@
+import freetypeTextTpl from 'scripts/liveblog-edit/views/freetype-text.html';
+
 export default function freetypeText() {
     return {
         restrict: 'E',
-        templateUrl: 'scripts/liveblog-edit/views/freetype-text.html',
+        templateUrl: freetypeTextTpl,
         controller: ['$scope', function($scope) {
             $scope._id = _.uniqueId('text');
             if ($scope.initial !== undefined && $scope.text === '') {

--- a/client/app/scripts/liveblog-edit/directives/item.js
+++ b/client/app/scripts/liveblog-edit/directives/item.js
@@ -1,8 +1,10 @@
+import itemTpl from 'scripts/liveblog-edit/views/item.html';
+
 export default function lbItem() {
     return {
         scope: {
             item: '='
         },
-        templateUrl: 'scripts/liveblog-edit/views/item.html',
+        templateUrl: itemTpl,
     }
 }

--- a/client/app/scripts/liveblog-edit/directives/post.js
+++ b/client/app/scripts/liveblog-edit/directives/post.js
@@ -1,3 +1,5 @@
+import postTpl from 'scripts/liveblog-edit/views/post.html';
+
 lbPost.$inject = [
     'notify',
     'gettext',
@@ -31,7 +33,7 @@ export default function lbPost(notify, gettext, asset, postsService, modal,
             postsListCtrl: '='
         },
         restrict: 'E',
-        templateUrl: 'scripts/liveblog-edit/views/post.html',
+        templateUrl: postTpl,
         link: function(scope, elem, attrs) {
             // if the escape key is press then clear the reorder action.
             function escClearReorder(e) {

--- a/client/app/scripts/liveblog-edit/directives/posts-list.js
+++ b/client/app/scripts/liveblog-edit/directives/posts-list.js
@@ -1,3 +1,5 @@
+import postsTpl from 'scripts/liveblog-edit/views/posts.html';
+
 lbPostsList.$inject = ['postsService', 'notify', '$q', '$timeout', 'session', 'PagesManager'];
 
 export default function lbPostsList(postsService, notify, $q, $timeout, session, PagesManager) {
@@ -155,7 +157,7 @@ export default function lbPostsList(postsService, notify, $q, $timeout, session,
         },
         restrict: 'EA',
         transclude: true,
-        templateUrl: 'scripts/liveblog-edit/views/posts.html',
+        templateUrl: postsTpl,
         controllerAs: 'postsList',
         controller: LbPostsListCtrl
     };

--- a/client/app/scripts/liveblog-edit/module.js
+++ b/client/app/scripts/liveblog-edit/module.js
@@ -12,6 +12,10 @@
 import angular from 'angular';
 import _ from 'lodash';
 
+import mainTpl from 'scripts/liveblog-edit/views/main.html';
+import settingsTpl from 'scripts/liveblog-edit/views/settings.html';
+import analiticsTpl from 'scripts/liveblog-analytics/views/view-analytics.html';
+
 import BlogEditController from './controllers/blog-edit.js'
 import BlogSettingsController from './controllers/blog-settings.js'
 
@@ -50,14 +54,14 @@ var app = angular.module('liveblog.edit', [
         auth: true,
         controller: BlogEditController,
         controllerAs: 'blogEdit',
-        templateUrl: 'scripts/liveblog-edit/views/main.html',
+        templateUrl: mainTpl,
         resolve: {blog: BlogResolver}
     }).activity('/liveblog/settings/:_id', {
         label: gettext('Blog Settings'),
         auth: true,
         controller: BlogSettingsController,
         controllerAs: 'settings',
-        templateUrl: 'scripts/liveblog-edit/views/settings.html',
+        templateUrl: settingsTpl,
         resolve: {
             blog: BlogResolver,
             security: ['blogSecurityService', function(blogSecurityService) {
@@ -69,7 +73,7 @@ var app = angular.module('liveblog.edit', [
         auth: true,
         controller: 'LiveblogAnalyticsController',
         controllerAs: 'analytics',
-        templateUrl: 'scripts/liveblog-analytics/views/view-analytics.html',
+        templateUrl: analiticsTpl,
         resolve: {
             blog: BlogResolver,
             security: ['blogSecurityService', function(blogSecurityService) {

--- a/client/app/scripts/liveblog-freetypes/module.js
+++ b/client/app/scripts/liveblog-freetypes/module.js
@@ -1,3 +1,5 @@
+import listViewTpl from 'scripts/liveblog-freetypes/views/list.html'
+
 LiveblogFreetypesController.$inject = ['api', '$location', 'notify', 'gettext',
 '$q', '$sce', 'config', 'lodash', 'upload', 'blogService', 'modal'];
 
@@ -136,7 +138,7 @@ $q, $sce, config, _, upload, blogService, modal) {
                     category: superdesk.MENU_MAIN,
                     adminTools: true,
                     privileges: {'global_preferences': 1},
-                    templateUrl: 'scripts/liveblog-freetypes/views/list.html'
+                    templateUrl: listViewTpl
                 });
     }])
     .config(['apiProvider', function(apiProvider) {

--- a/client/app/scripts/liveblog-marketplace/directives/blog-preview-modal.js
+++ b/client/app/scripts/liveblog-marketplace/directives/blog-preview-modal.js
@@ -1,8 +1,10 @@
+import previewModalTpl from 'scripts/liveblog-marketplace/views/blog-preview-modal.html';
+
 lbBlogPreviewModal.$inject = ['MarketplaceActions', '$sce'];
 
 export default function lbBlogPreviewModal(MarketplaceActions, $sce) {
     return {
-        templateUrl: 'scripts/liveblog-marketplace/views/blog-preview-modal.html',
+        templateUrl: previewModalTpl,
         scope: {
             store: '='
         },

--- a/client/app/scripts/liveblog-marketplace/directives/blogs-list.js
+++ b/client/app/scripts/liveblog-marketplace/directives/blogs-list.js
@@ -1,8 +1,10 @@
+import blogsListTpl from 'scripts/liveblog-marketplace/views/blogs-list.html';
+
 lbBlogsList.$inject = ['MarketplaceActions'];
 
 export default function lbBlogsList(MarketplaceActions) {
     return {
-        templateUrl: 'scripts/liveblog-marketplace/views/blogs-list.html',
+        templateUrl: blogsListTpl,
         scope: {
             title: '@',
             blogs: '='

--- a/client/app/scripts/liveblog-marketplace/directives/marketplace-switch.js
+++ b/client/app/scripts/liveblog-marketplace/directives/marketplace-switch.js
@@ -1,6 +1,8 @@
+import marketplatplaceSwitchTpl from 'scripts/liveblog-marketplace/views/marketplace-switch.html';
+
 export default function lbMarketplaceSwitch() {
     return {
-        templateUrl: 'scripts/liveblog-marketplace/views/marketplace-switch.html',
+        templateUrl: marketplatplaceSwitchTpl,
         scope: {
             marketEnabled: '='
         }

--- a/client/app/scripts/liveblog-marketplace/directives/search-panel.js
+++ b/client/app/scripts/liveblog-marketplace/directives/search-panel.js
@@ -1,8 +1,10 @@
+import searchPanelTpl from 'scripts/liveblog-marketplace/views/search-panel.html';
+
 lbSearchPanel.$inject = ['MarketplaceActions'];
 
 export default function lbSearchPanel(MarketplaceActions) {
     return {
-        templateUrl: 'scripts/liveblog-marketplace/views/search-panel.html',
+        templateUrl: searchPanelTpl,
         scope: {
             store: '='
         },

--- a/client/app/scripts/liveblog-marketplace/index.js
+++ b/client/app/scripts/liveblog-marketplace/index.js
@@ -1,6 +1,8 @@
 import './styles/marketplace.scss';
 import './../flux';
 
+import marketplaceTpl from 'scripts/liveblog-marketplace/views/marketplace.html';
+
 import marketplaceController from './controllers/marketplace';
 
 import marketplaceActions from './actions/marketplace';
@@ -25,7 +27,7 @@ export default angular
             .activity('/marketplace/', {
                 label: gettext('Marketplace'),
                 controller: 'MarketplaceController',
-                templateUrl: 'scripts/liveblog-marketplace/views/marketplace.html',
+                templateUrl: marketplaceTpl,
                 category: superdesk.MENU_MAIN,
                 priority: 100,
                 adminTools: true,

--- a/client/app/scripts/liveblog-settings/module.js
+++ b/client/app/scripts/liveblog-settings/module.js
@@ -1,3 +1,5 @@
+import generalTpl from 'scripts/liveblog-settings/views/general.html';
+
 (function() {
     LiveblogSettingsController.$inject = ['$scope', 'api', '$location', 'notify', 'gettext', '$q'];
     function LiveblogSettingsController($scope, api, $location, notify, gettext, $q) {
@@ -48,7 +50,7 @@
             .activity('/settings/', {
                 label: gettext('Liveblog'),
                 controller: LiveblogSettingsController,
-                templateUrl: 'scripts/liveblog-settings/views/general.html'
+                templateUrl: generalTpl
             });
     }])
     .config(['apiProvider', function(apiProvider) {

--- a/client/app/scripts/liveblog-syndication/activities.js
+++ b/client/app/scripts/liveblog-syndication/activities.js
@@ -1,3 +1,5 @@
+import syndicationTpl from 'scripts/liveblog-syndication/views/syndication.html';
+
 activities.$inject = ['superdeskProvider'];
 
 export default function activities(superdesk) {
@@ -5,7 +7,7 @@ export default function activities(superdesk) {
         .activity('/syndication/', {
             label: gettext('Syndication'),
             controller: 'SyndicationController',
-            templateUrl: 'scripts/liveblog-syndication/views/syndication.html',
+            templateUrl: syndicationTpl,
             category: superdesk.MENU_MAIN,
             priority: 100,
             adminTools: true,

--- a/client/app/scripts/liveblog-syndication/directives/attach-syndicated-blogs-modal.js
+++ b/client/app/scripts/liveblog-syndication/directives/attach-syndicated-blogs-modal.js
@@ -1,8 +1,10 @@
+import attachSyndicatedBlogsModalTpl from 'scripts/liveblog-syndication/views/attach-syndicated-blogs-modal.html';
+
 attachSyndicatedBlogsModal.$inject = ['$q', 'lodash', 'IngestPanelActions']; 
 
 export default function attachSyndicatedBlogsModal($q, _, IngestPanelActions) {
     return {
-        templateUrl: 'scripts/liveblog-syndication/views/attach-syndicated-blogs-modal.html',
+        templateUrl: attachSyndicatedBlogsModalTpl,
         scope: {
             store: '='
         },

--- a/client/app/scripts/liveblog-syndication/directives/consumer-edit.js
+++ b/client/app/scripts/liveblog-syndication/directives/consumer-edit.js
@@ -1,8 +1,10 @@
+import consumerEditFormTpl from 'scripts/liveblog-syndication/views/consumer-edit-form.html';
+
 consumerEdit.$inject = ['api', 'notify', 'lodash'];
 
 export default function consumerEdit(api, notify, _) {
     return {
-        templateUrl: 'scripts/liveblog-syndication/views/consumer-edit-form.html',
+        templateUrl: consumerEditFormTpl,
         scope: {
             consumer: '=',
             onsave: '&',

--- a/client/app/scripts/liveblog-syndication/directives/consumer-list.js
+++ b/client/app/scripts/liveblog-syndication/directives/consumer-list.js
@@ -1,8 +1,10 @@
+import consumerListItemTpl from 'scripts/liveblog-syndication/views/consumer-list-item.html';
+
 consumerList.$inject = ['api', 'notify'];
 
 export default function consumerList(api, notify) {
     return {
-        templateUrl: 'scripts/liveblog-syndication/views/consumer-list-item.html',
+        templateUrl: consumerListItemTpl,
         scope: {
             roles: '=',
             consumers: '=',

--- a/client/app/scripts/liveblog-syndication/directives/consumers.js
+++ b/client/app/scripts/liveblog-syndication/directives/consumers.js
@@ -1,6 +1,8 @@
+import consumerListTpl from 'scripts/liveblog-syndication/views/consumer-list.html';
+
 export default function lbConsumers() {
     return {
-        templateUrl: 'scripts/liveblog-syndication/views/consumer-list.html',
+        templateUrl: consumerListTpl,
         controller: ['$scope', '$controller', function($scope, $controller) {
             $scope.endPoint = 'consumers';
             $scope.entryName = 'consumer';

--- a/client/app/scripts/liveblog-syndication/directives/contacts-edit.js
+++ b/client/app/scripts/liveblog-syndication/directives/contacts-edit.js
@@ -1,6 +1,8 @@
+import contactsEditFormTpl from 'scripts/liveblog-syndication/views/contacts-edit-form.html';
+
 export default function contactsEdit() {
     return {
-        templateUrl: 'scripts/liveblog-syndication/views/contacts-edit-form.html',
+        templateUrl: contactsEditFormTpl,
         scope: {
             contacts: '=',
             attempted: '='

--- a/client/app/scripts/liveblog-syndication/directives/incoming-syndication.js
+++ b/client/app/scripts/liveblog-syndication/directives/incoming-syndication.js
@@ -1,3 +1,5 @@
+import incomingSyndicationTpl from 'scripts/liveblog-syndication/views/incoming-syndication.html';
+
 incomingSyndication.$inject = [
   '$routeParams',
   'IncomingSyndicationActions',
@@ -9,7 +11,7 @@ incomingSyndication.$inject = [
 export default function incomingSyndication($routeParams, IncomingSyndicationActions,
     IncomingSyndicationReducers, Store, modal) {
     return {
-        templateUrl: 'scripts/liveblog-syndication/views/incoming-syndication.html',
+        templateUrl: incomingSyndicationTpl,
         scope: {
             lbPostsOnPostSelected: '=',
             openPanel: '=',

--- a/client/app/scripts/liveblog-syndication/directives/ingest-panel-dropdown.js
+++ b/client/app/scripts/liveblog-syndication/directives/ingest-panel-dropdown.js
@@ -1,8 +1,10 @@
+import ingestPanelDropdownTpl from 'scripts/liveblog-syndication/views/ingest-panel-dropdown.html';
+
 ingestPanelDropdown.$inject = ['IngestPanelActions'];
 
 export default function ingestPanelDropdown(IngestPanelActions) {
     return {
-        templateUrl: 'scripts/liveblog-syndication/views/ingest-panel-dropdown.html',
+        templateUrl: ingestPanelDropdownTpl,
         scope: {
             consumerBlogId: '=',
             blog: '='

--- a/client/app/scripts/liveblog-syndication/directives/ingest-panel.js
+++ b/client/app/scripts/liveblog-syndication/directives/ingest-panel.js
@@ -1,3 +1,5 @@
+import ingestPanelTpl from 'scripts/liveblog-syndication/views/ingest-panel.html';
+
 ingestPanel.$inject = [
   'IngestPanelActions',
   'Store',
@@ -8,7 +10,7 @@ ingestPanel.$inject = [
 
 export default function ingestPanel(IngestPanelActions, Store, IngestPanelReducers, $routeParams, notify) {
     return {
-        templateUrl: 'scripts/liveblog-syndication/views/ingest-panel.html',
+        templateUrl: ingestPanelTpl,
         link: function(scope) {
 
             var handleError = function() {

--- a/client/app/scripts/liveblog-syndication/directives/producer-edit.js
+++ b/client/app/scripts/liveblog-syndication/directives/producer-edit.js
@@ -1,8 +1,10 @@
+import producerEditFormTpl from 'scripts/liveblog-syndication/views/producer-edit-form.html';
+
 producerEdit.$inject = ['api', 'notify', 'lodash'];
 
 export default function producerEdit(api, notify, _) {
     return {
-        templateUrl: 'scripts/liveblog-syndication/views/producer-edit-form.html',
+        templateUrl: producerEditFormTpl,
         scope: {
             producer: '=',
             onsave: '&',

--- a/client/app/scripts/liveblog-syndication/directives/producer-list.js
+++ b/client/app/scripts/liveblog-syndication/directives/producer-list.js
@@ -1,8 +1,10 @@
+import producerListItemTpl from 'scripts/liveblog-syndication/views/producer-list-item.html';
+
 producerList.$inject = ['api'];
 
 export default function producerList(api) {
     return {
-        templateUrl: 'scripts/liveblog-syndication/views/producer-list-item.html',
+        templateUrl: producerListItemTpl,
         scope: {
             roles: '=',
             producers: '=',

--- a/client/app/scripts/liveblog-syndication/directives/producers.js
+++ b/client/app/scripts/liveblog-syndication/directives/producers.js
@@ -1,6 +1,8 @@
+import producerListTpl from 'scripts/liveblog-syndication/views/producer-list.html';
+
 export default function lbProducers() {
     return {
-        templateUrl: 'scripts/liveblog-syndication/views/producer-list.html',
+        templateUrl: producerListTpl,
         controller: ['$scope', '$controller', function($scope, $controller) {
             $scope.endPoint = 'producers';
             $scope.entryName = 'producer';

--- a/client/app/scripts/liveblog-syndication/directives/syndication-switch.js
+++ b/client/app/scripts/liveblog-syndication/directives/syndication-switch.js
@@ -1,8 +1,10 @@
+import syndicationSwitchTpl from 'scripts/liveblog-syndication/views/syndication-switch.html';
+
 syndicationSwitch.$inject = ['api', '$routeParams'];
 
 export default function syndicationSwitch(api, $routeParams) {
     return {
-        templateUrl: 'scripts/liveblog-syndication/views/syndication-switch.html',
+        templateUrl: syndicationSwitchTpl,
         link: function(scope) {
             scope.enableSyndSwitch = true;
 

--- a/client/app/scripts/liveblog-themes/directives.js
+++ b/client/app/scripts/liveblog-themes/directives.js
@@ -7,6 +7,8 @@
  * AUTHORS and LICENSE files distributed with this source code, or
  * at https://www.sourcefabric.org/superdesk/license
  */
+import dateFormTpl from 'scripts/liveblog-themes/views/date-format.html';
+
 (function() {
     angular.module('liveblog.themes')
         .directive('lbDateFormat', [function() {
@@ -15,7 +17,7 @@
                     options: '=',
                     value: '=ngModel'
                 },
-                templateUrl: 'scripts/liveblog-themes/views/date-format.html',
+                templateUrl: dateFormTpl,
                 link: function(scope) {
                     if (scope.options.indexOf(scope.value) !== -1) {
                         scope.radio = scope.value;

--- a/client/app/scripts/liveblog-themes/module.js
+++ b/client/app/scripts/liveblog-themes/module.js
@@ -1,3 +1,5 @@
+import listTpl from 'scripts/liveblog-themes/views/list.html';
+
 (function() {
     LiveblogThemesController.$inject = ['api', '$location', 'notify', 'gettext',
     '$q', '$sce', 'config', 'lodash', 'upload', 'blogService', '$window'];
@@ -272,7 +274,7 @@
                 category: superdesk.MENU_MAIN,
                 adminTools: true,
                 privileges: {'global_preferences': 1},
-                templateUrl: 'scripts/liveblog-themes/views/list.html'
+                templateUrl: listTpl
             });
     }])
     .filter('githubUrlFromGit', function() {

--- a/client/app/scripts/liveblog-themes/theme-settings-modal.js
+++ b/client/app/scripts/liveblog-themes/theme-settings-modal.js
@@ -1,3 +1,5 @@
+import themeSettingsModalTpl from 'scripts/liveblog-themes/views/theme-settings-modal.html';
+
 (function() {
     angular.module('liveblog.themes')
     .filter('exampleDate', [ 'moment', function(moment) {
@@ -8,7 +10,7 @@
     .directive('themeSettingsModal', ['api', '$q', 'notify',
         function(api, $q, notify) {
             return {
-                templateUrl: 'scripts/liveblog-themes/views/theme-settings-modal.html',
+                templateUrl: themeSettingsModalTpl,
                 scope: {
                     theme: '=',
                     modalOpened: '='

--- a/client/package.json
+++ b/client/package.json
@@ -57,6 +57,7 @@
     "less-loader": "^2.2.3",
     "load-grunt-config": "0.17.1",
     "load-grunt-tasks": "3.2.0",
+    "ngtemplate-loader": "^1.3.1",
     "node-sass": "^4.3.0",
     "phantomjs": "^2.1.3",
     "protractor": "^4.0.13",

--- a/client/tasks/options/copy.js
+++ b/client/tasks/options/copy.js
@@ -10,7 +10,7 @@ module.exports = {
                 'images/**/*',
                 'favicon.ico',
                 'styles/css/*.css',
-                'scripts/**/*.{html,css,jpg,jpeg,png,gif,json}',
+                //'scripts/**/*.{html,css,jpg,jpeg,png,gif,json}',
                 'scripts/bower_components/requirejs/require.js'
             ]
         },{

--- a/client/tasks/options/webpack-dev-server.js
+++ b/client/tasks/options/webpack-dev-server.js
@@ -13,7 +13,7 @@ module.exports = function(grunt) {
             port: 9000,
             host: '0.0.0.0',
             contentBase: './dist',
-            hot: true,
+            hot: false,
             headers: {
                 'Cache-Control': 'no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0'
             }

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -121,7 +121,7 @@ module.exports = function makeConfig(grunt) {
                 //},
                 {
                     test: /\.html$/,
-                    loader: 'html'
+                    loader: 'ngtemplate!html'
                 },
                 {
                     test: /\.css/,


### PR DESCRIPTION
Before this, when templates where changed, the client server needed to be restarted or the copy:assets grunt task had to be run and the browser refreshed in order for the changes to be visible. Also no template cache was available for the the views. 

JIRA issue [LBSD-1509](https://dev.sourcefabric.org/browse/LBSD-1509)
### Objectives
- [x] Rebuild the bundle after template change
- [x] Automatically refresh the browser after template change
- [x] Use template cacheing mechanism for views
- [x] Remove the copying of views in dist folder for LB components

### Actions taken
- [x] Add extra webpack loader to cache templates
- [x] Switch off 'hot' building of the bundle
- [x] Import all views and activity templates 
- [x] Remove the copying of views/templates in dist folder for LB components from the copy:assets task