### PR TITLE
LP-63 change number of allowed users for subscriptions of type solo and team

### DIFF
--- a/client/tasks/options/template.js
+++ b/client/tasks/options/template.js
@@ -23,8 +23,8 @@ module.exports = function(grunt) {
             themeCreationRestrictions: {team: 3},
             excludedTheme: 'angular',
             assignableUsers: {
-                solo: 3,
-                team: 5
+                solo: 2,
+                team: 4
             },
             subscriptionLevel: process.env.SUBSCRIPTION_LEVEL || '',
             blogCreationRestrictions: {


### PR DESCRIPTION
For Live Blog Solo (Solo Mobile): Change max number of team members from 3 to 2.
For Live Blog Team: Change max number of team members from 5 to 4.
