### PR TITLE
Remove travis encryption

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ dist: trusty
 env:
     global:
         - CXX=g++-4.8
-        - secure: ajoP9pA/FYH+1sFwGKHlQ8PoGqRIjdmqEnwo44AA5j6c1NMsgiToA420lPm8Lp0cko5YK3ppBlGlvbRWu5JXVxl0vMtZTLf3FM2w99viddrRCkh4sMef2DzkXXYOW4Tnew/8pmaOtTn3UtNG/feJHkBzHLEDUuN0TA07Y6UaWHc=
         # do not load /etc/boto.cfg with Python 3 incompatible plugin
         # https://github.com/travis-ci/travis-ci/issues/5246#issuecomment-166460882
         - BOTO_CONFIG=/doesnotexist


### PR DESCRIPTION
It's now possible to add environment variables directly via the admin interface, thus enabling the possibility of making PRs from forks.

https://travis-ci.org/liveblog/liveblog/settings