### PR TITLE
Fix deployment issue

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -49,7 +49,7 @@ def get_app(config=None):
 
     config['DOMAIN'] = {}
 
-    app = superdesk_app(config, media_storage)
+    app = superdesk_app(config, media_storage, init_elastic=True)
 
     custom_loader = jinja2.ChoiceLoader([
         jinja2.FileSystemLoader('superdesk/templates'),

--- a/server/settings.py
+++ b/server/settings.py
@@ -249,7 +249,7 @@ if LDAP_SERVER:
 else:
     INSTALLED_APPS.append('apps.auth.db')
 
-SUPERDESK_TESTING = (env('SUPERDESK_TESTING', 'true').lower() == 'true')
+SUPERDESK_TESTING = (env('SUPERDESK_TESTING', 'false').lower() == 'true')
 
 # Debuging state, this is used when generating theme emebed files default `false`.
 LIVEBLOG_DEBUG = (env('LIVEBLOG_DEBUG', 'false').lower() == 'true')


### PR DESCRIPTION
On new database without blogs when I run
```sh
# first time
./manage.py app:initialize_data
./manage.py register_local_themes
# All good

# but second time
./manage.py app:initialize_data
./manage.py register_local_themes

# get Exception like:
WARNING:elasticsearch:GET /lbpr-744/blogs/_search [status:404 request:0.001s]
DEBUG:elasticsearch:> {"sort": [{"_updated": "desc"}], "query": {"filtered": {"filter": {"and": [{"and": [{"term": {"blog_preferences.theme": "classic"}}]}]}}}}
DEBUG:elasticsearch:< {"error":{"root_cause":[{"type":"index_not_found_exception","reason":"no such index","resource.type":"index_or_alias","resource.id":"lbpr-744","index":"lbpr-744"}],"type":"index_not_found_exception","reason":"no such index","resource.type":"index_or_alias","resource.id":"lbpr-744","index":"lbpr-744"},"status":404}
INFO:superdesk:Uhoh, an exception occured while running the command...
ERROR:superdesk:TransportError(404, 'index_not_found_exception', 'no such index')
Traceback (most recent call last):
  File "/opt/liveblog/env/src/superdesk-core/superdesk/__init__.py", line 61, in __call__
    res = self.run(*args, **kwargs)
  File "/opt/liveblog/server/liveblog/themes/themes.py", line 416, in run
    created, updated = theme_service.update_registered_theme_with_local_files(force=True)
  File "/opt/liveblog/server/liveblog/themes/themes.py", line 170, in update_registered_theme_with_local_files
    result = self.save_or_update_theme(theme, files, force_update=force)
  File "/opt/liveblog/server/liveblog/themes/themes.py", line 240, in save_or_update_theme
    blogs = blogs_service.get(req=None, lookup={'blog_preferences.theme': previous_theme['name']})
  File "/opt/liveblog/env/src/superdesk-core/superdesk/services.py", line 94, in get
    return self.backend.get(self.datasource, req=req, lookup=lookup)
  File "/opt/liveblog/env/src/superdesk-core/superdesk/eve_backend.py", line 87, in get
    cursor = backend.find(endpoint_name, req, lookup)
  File "/opt/liveblog/env/lib/python3.5/site-packages/eve_elastic/elastic.py", line 439, in find
    hits = self.elastic(resource).search(body=query, **args)
  File "/opt/liveblog/env/lib/python3.5/site-packages/elasticsearch/client/utils.py", line 69, in _wrapped
    return func(*args, params=params, **kwargs)
  File "/opt/liveblog/env/lib/python3.5/site-packages/elasticsearch/client/__init__.py", line 539, in search
    doc_type, '_search'), params=params, body=body)
  File "/opt/liveblog/env/lib/python3.5/site-packages/elasticsearch/transport.py", line 327, in perform_request
    status, headers, data = connection.perform_request(method, url, params, body, ignore=ignore, timeout=timeout)
  File "/opt/liveblog/env/lib/python3.5/site-packages/elasticsearch/connection/http_urllib3.py", line 110, in perform_request
    self._raise_error(response.status, raw_data)
  File "/opt/liveblog/env/lib/python3.5/site-packages/elasticsearch/connection/base.py", line 114, in _raise_error
    raise HTTP_EXCEPTIONS.get(status_code, TransportError)(status_code, error_message, additional_info)
elasticsearch.exceptions.NotFoundError: TransportError(404, 'index_not_found_exception', 'no such index')
```

~After some investigation I found that is wrong usage of `'search_backend': 'elastic'`, there are no reasons to use here `elasticsearch`.~

In the end, I found that mappings didn't get elastic during `./mange.py` run.

Some logs from CI server with such errors:
- https://test.superdesk.org/logs/1/all/20170405-105524-72-lb-fixscorers/www.log.htm
- https://test.superdesk.org/logs/1/all/20170405-084237-32-lb-fixsyndicationwebhookstatus/www.log