### PR TITLE
LBSD-1448 fix wrong item count

### DIFF
--- a/client/app/scripts/liveblog-edit/posts.service.js
+++ b/client/app/scripts/liveblog-edit/posts.service.js
@@ -121,11 +121,15 @@ export default function postsService(api, $q, userList) {
         return obj;
     }
     function _completePost(post) {
+        let multipleItems = false;
+
+        if (post.groups[1].refs.length > 1) {
+            multipleItems = post.groups[1].refs.length - 1;
+        }
+
         return $q(function(resolve, reject) {
             angular.extend(post, {
-                // add a `multiple_items` field. Can be false or a positive integer.
-                // FIXME: left like that to support other feature, but this need to be in camelcase
-                multiple_items: post.groups[1].refs.length > 1 ? post.groups[1].refs.length : false,
+                multipleItems: multipleItems,
                 // add a `mainItem` field containing the first item
                 mainItem: post.groups[1].refs[0],
                 items: post.groups[1].refs

--- a/client/app/scripts/liveblog-edit/styles/post.scss
+++ b/client/app/scripts/liveblog-edit/styles/post.scss
@@ -106,7 +106,8 @@
         &-multiple-items {
             position: relative;
             top: -7px;
-            width: 70px;
+            //width: 70px;
+            width: 128px;
             height: 13px;
             right: 40px;
             float: right;
@@ -120,12 +121,14 @@
             background-color: #a6a6a6;
             margin-left:-40px;
             margin-right:4px;
+            position: relative;
         }
         &-multiple-items-roundel-text {
             position: absolute;
             top: -2px;
             left: 0;
-            width: 26px;
+            //width: 26px;
+            width: 20px;
             text-align: center;
             color: #f6f6f6;
             font-size: 11px;

--- a/client/app/scripts/liveblog-edit/views/post.html
+++ b/client/app/scripts/liveblog-edit/views/post.html
@@ -79,7 +79,7 @@
                         </ul>
                     </div>
                 </div>
-                <div ng-if="post.multiple_items" class="lb-post__list">
+                <div ng-if="post.multipleItems" class="lb-post__list">
                     <div ng-if="!show_all" title="Click to show all items" ng-click="toggleMultipleItems()" class="multiple-item lb-post__item">
                         <lb-item item="post.mainItem.item"></lb-item>
                     </div>
@@ -111,19 +111,29 @@
                          </div>
                 </div>
             </div>
-                <div ng-if="!post.multiple_items" class="lb-post__list">
+                <div ng-if="!post.multipleItems" class="lb-post__list">
                         <lb-item item="post.mainItem.item"></lb-item>
                 </div>
         </div>
-        <a class="lb-post__expander-holder" ng-click="toggleMultipleItems()" ng-if="post.multiple_items && !show_all">
+        <a
+            class="lb-post__expander-holder"
+            ng-click="toggleMultipleItems()"
+            ng-if="post.multipleItems && !show_all">
             <div class="lb-post__expander-multiple-items">
                 <div class="lb-post__expander-multiple-items-roundel">
-                    <div class="lb-post__expander-multiple-items-roundel-text">{{ post.multiple_items }}</div>
+                    <div class="lb-post__expander-multiple-items-roundel-text">
+                        {{ post.multipleItems }}
+                    </div>
                 </div>
-                <div translate class="lb-post__expander-multiple-items-roundel-label">ITEMS</div>
+                <div translate class="lb-post__expander-multiple-items-roundel-label">
+                    MORE ITEMS
+                </div>
             </div>
         </a>
-        <a class="lb-post__expander-holder" ng-click="toggleMultipleItems()" ng-if="post.multiple_items && show_all">
+        <a
+            class="lb-post__expander-holder"
+            ng-click="toggleMultipleItems()"
+            ng-if="post.multipleItems && show_all">
             <div class="lb-post__collapser-multiple-items"></div>
         </a>
     </div>


### PR DESCRIPTION
Multiple items is now camel case and representing the number of items that are currently hidden in the timeline view. In opposition to display the count of all the items for the post.