### PR TITLE
Revert superdesk-core to version 1.6 (#777)

### DIFF
--- a/server/liveblog/syndication/syndication.py
+++ b/server/liveblog/syndication/syndication.py
@@ -248,7 +248,7 @@ def syndication_webhook():
     if in_syndication is None:
         return api_error('Blog is not being syndication', 406)
 
-    blog_service = get_resource_service('blogs')
+    blog_service = get_resource_service('client_blogs')
     blog = blog_service.find_one(req=None, _id=in_syndication['blog_id'])
     if blog is None:
         return api_error('Blog not found', 404)

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,12 +1,75 @@
-gunicorn==19.6.0
-honcho==0.6.6
-newrelic>=2.66,<2.67
-
-# Liveblog
+amqp==2.1.4
+appdirs==1.4.0
+arrow==0.10.0
+asyncio==3.4.3
+bcrypt==3.1.3
+beautifulsoup4==4.5.3
+behave==1.2.5
+billiard==3.5.0.2
+blinker==1.4
+boto==2.45.0
+boto3==1.4.4
+botocore==1.5.14
+celery==4.0.2
+Cerberus==0.9.2
+cffi==1.10.0
+contextlib2==0.5.4
+docutils==0.13.1
+elasticsearch==1.9.0
+Eve==0.6.4
+Eve-Elastic==0.3.8
+Events==0.2.2
+feedparser==5.2.1
+Flask==0.10.1
 Flask-Cache==0.13.1
 Flask-Cors==2.1.0
+Flask-Mail==0.9.1
+Flask-PyMongo==0.4.1
 Flask-S3==0.1.7
+Flask-Script==2.0.5
+gunicorn==19.3.0
+hachoir3-superdesk==3.0a1.post2
+HermesCache==0.6.1
+honcho==0.7.1
 html5lib==0.999999999
+itsdangerous==0.24
+Jinja2==2.9.5
+jmespath==0.9.1
+kombu==4.0.2
+lxml==3.7.2
+MarkupSafe==0.23
+mccabe==0.6.1
+mongolock==1.3.4
+olefile==0.44
+packaging==16.8
+parse==1.6.6
+parse-type==0.3.4
+Pillow==4.0.0
+pyasn1==0.2.2
+pycodestyle==2.3.1
+pycparser==2.17
+pymongo==3.4.0
+pyparsing==2.1.10
+python-dateutil==2.6.0
+python-magic==0.4.12
+python3-ldap==0.9.8.4
+pytz==2016.10
+PyYAML==3.12
+raven==5.10.2
+redis==2.10.5
+requests==2.13.0
+s3transfer==0.1.10
+simplejson==3.10.0
+six==1.10.0
+statsd==3.2.1
+tzlocal==1.3
+urllib3==1.20
+vine==1.1.3
+webencodings==0.5
+websockets==3.2
+Werkzeug==0.11.15
 
 # Superdesk
--e git://github.com/superdesk/superdesk-core.git@994045d6d#egg=Superdesk-Core
+-e git://github.com/superdesk/superdesk-core.git@750a78b#egg=Superdesk-Core-1.6
+#-e git://github.com/superdesk/superdesk-core.git@994045d6d#egg=Superdesk-Core
+#-e git+git://github.com/liveblog/superdesk-core.git@4656deb0fd9a336df663c2e4e90f66ec4d276716#egg=Superdesk-Core==1.2-fix-celery-issue

--- a/server/settings.py
+++ b/server/settings.py
@@ -315,3 +315,6 @@ NO_TAKES = True
 
 # Blog embeds S3 publishing options.
 S3_PUBLISH_BLOGSLIST = env('S3_PUBLISH_BLOGSLIST', True)
+
+# Superdesk-core related settings.
+CONTENTAPI_URL = None


### PR DESCRIPTION
* Revert to superdesk-core 1.6
* Update bcrypt and cffi packages
* Add CONTENTAPI_URL setting
* Remove duplicated dependencies in requirements.txt.
* Use client_blogs instead of blogs resource to prevent permission errors.