### PR TITLE
Add strict mode to client/webpack.config.js

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -4,6 +4,7 @@ var lodash = require('lodash');
 
 // makeConfig creates a new configuration file based on the passed options.
 module.exports = function makeConfig(grunt) {
+    'use strict';
     var appConfigPath = path.join(process.cwd(), 'superdesk.config.js');
 
     if (process.env.SUPERDESK_CONFIG) {


### PR DESCRIPTION
I am getting "SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode" when running grunt on a machine that is running npm 4.5.0 and node 4.8.2.

```
vagrant@vagrant-ubuntu-trusty-64:/opt/superdesk/client$ npm -v
4.5.0
vagrant@vagrant-ubuntu-trusty-64:/opt/superdesk/client$ node -v
v4.8.2
vagrant@vagrant-ubuntu-trusty-64:/opt/superdesk/client$ grunt -v
Initializing
Command-line options: --verbose

Reading "Gruntfile.js" Gruntfile...OK

Registering Gruntfile tasks.
Reading ./package.json...OK
Parsing ./package.json...OK
Initializing config...OK

Registering "grunt-angular-gettext" local Npm module tasks.
Reading /opt/superdesk/client/node_modules/grunt-angular-gettext/package.json...OK
Parsing /opt/superdesk/client/node_modules/grunt-angular-gettext/package.json...OK
Loading "compile.js" tasks...OK
+ nggettext_compile
Loading "extract.js" tasks...OK
+ nggettext_extract

Registering "grunt-angular-templates" local Npm module tasks.
Reading /opt/superdesk/client/node_modules/grunt-angular-templates/package.json...OK
Parsing /opt/superdesk/client/node_modules/grunt-angular-templates/package.json...OK
Loading "angular-templates.js" tasks...OK
+ ngtemplates

Registering "grunt-contrib-clean" local Npm module tasks.
Reading /opt/superdesk/client/node_modules/grunt-contrib-clean/package.json...OK
Parsing /opt/superdesk/client/node_modules/grunt-contrib-clean/package.json...OK
Loading "clean.js" tasks...OK
+ clean

Registering "grunt-contrib-concat" local Npm module tasks.
Reading /opt/superdesk/client/node_modules/grunt-contrib-concat/package.json...OK
Parsing /opt/superdesk/client/node_modules/grunt-contrib-concat/package.json...OK
Loading "concat.js" tasks...OK
+ concat

Registering "grunt-contrib-connect" local Npm module tasks.
Reading /opt/superdesk/client/node_modules/grunt-contrib-connect/package.json...OK
Parsing /opt/superdesk/client/node_modules/grunt-contrib-connect/package.json...OK
Loading "connect.js" tasks...OK
+ connect

Registering "grunt-contrib-copy" local Npm module tasks.
Reading /opt/superdesk/client/node_modules/grunt-contrib-copy/package.json...OK
Parsing /opt/superdesk/client/node_modules/grunt-contrib-copy/package.json...OK
Loading "copy.js" tasks...OK
+ copy

Registering "grunt-contrib-cssmin" local Npm module tasks.
Reading /opt/superdesk/client/node_modules/grunt-contrib-cssmin/package.json...OK
Parsing /opt/superdesk/client/node_modules/grunt-contrib-cssmin/package.json...OK
Loading "cssmin.js" tasks...OK
+ cssmin

Registering "grunt-contrib-jshint" local Npm module tasks.
Reading /opt/superdesk/client/node_modules/grunt-contrib-jshint/package.json...OK
Parsing /opt/superdesk/client/node_modules/grunt-contrib-jshint/package.json...OK
Loading "jshint.js" tasks...OK
+ jshint

Registering "grunt-contrib-requirejs" local Npm module tasks.
Reading /opt/superdesk/client/node_modules/grunt-contrib-requirejs/package.json...OK
Parsing /opt/superdesk/client/node_modules/grunt-contrib-requirejs/package.json...OK
Loading "requirejs.js" tasks...OK
+ requirejs

Registering "grunt-contrib-uglify" local Npm module tasks.
Reading /opt/superdesk/client/node_modules/grunt-contrib-uglify/package.json...OK
Parsing /opt/superdesk/client/node_modules/grunt-contrib-uglify/package.json...OK
Loading "uglify.js" tasks...OK
+ uglify

Registering "grunt-contrib-watch" local Npm module tasks.
Reading /opt/superdesk/client/node_modules/grunt-contrib-watch/package.json...OK
Parsing /opt/superdesk/client/node_modules/grunt-contrib-watch/package.json...OK
Loading "watch.js" tasks...OK
+ watch

Registering "grunt-eslint" local Npm module tasks.
Reading /opt/superdesk/client/node_modules/grunt-eslint/package.json...OK
Parsing /opt/superdesk/client/node_modules/grunt-eslint/package.json...OK
Loading "eslint.js" tasks...OK
+ eslint

Registering "grunt-filerev" local Npm module tasks.
Reading /opt/superdesk/client/node_modules/grunt-filerev/package.json...OK
Parsing /opt/superdesk/client/node_modules/grunt-filerev/package.json...OK
Loading "filerev.js" tasks...OK
+ filerev

Registering "grunt-jscs" local Npm module tasks.
Reading /opt/superdesk/client/node_modules/grunt-jscs/package.json...OK
Parsing /opt/superdesk/client/node_modules/grunt-jscs/package.json...OK
Loading "jscs.js" tasks...OK
+ jscs

Registering "grunt-karma" local Npm module tasks.
Reading /opt/superdesk/client/node_modules/grunt-karma/package.json...OK
Parsing /opt/superdesk/client/node_modules/grunt-karma/package.json...OK
Loading "grunt-karma.js" tasks...OK
+ karma

Registering "grunt-karma-coveralls" local Npm module tasks.
Reading /opt/superdesk/client/node_modules/grunt-karma-coveralls/package.json...OK
Parsing /opt/superdesk/client/node_modules/grunt-karma-coveralls/package.json...OK
Loading "main.js" tasks...OK
+ coveralls

Registering "grunt-open" local Npm module tasks.
Reading /opt/superdesk/client/node_modules/grunt-open/package.json...OK
Parsing /opt/superdesk/client/node_modules/grunt-open/package.json...OK
Loading "open.js" tasks...OK
+ open

Registering "grunt-template" local Npm module tasks.
Reading /opt/superdesk/client/node_modules/grunt-template/package.json...OK
Parsing /opt/superdesk/client/node_modules/grunt-template/package.json...OK
Loading "template.js" tasks...OK
+ template

Registering "grunt-usemin" local Npm module tasks.
Reading /opt/superdesk/client/node_modules/grunt-usemin/package.json...OK
Parsing /opt/superdesk/client/node_modules/grunt-usemin/package.json...OK
Loading "usemin.js" tasks...OK
+ usemin, useminPrepare

Registering "grunt-webpack" local Npm module tasks.
Reading /opt/superdesk/client/node_modules/grunt-webpack/package.json...OK
Parsing /opt/superdesk/client/node_modules/grunt-webpack/package.json...OK
Loading "webpack-dev-server.js" tasks...OK
+ webpack-dev-server
Loading "webpack.js" tasks...OK
+ webpack
Loading "Gruntfile.js" tasks...ERROR
>> SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
>>     at exports.runInThisContext (vm.js:53:16)
>>     at Module._compile (module.js:373:25)
>>     at Object.Module._extensions..js (module.js:416:10)
>>     at Module.load (module.js:343:32)
>>     at Function.Module._load (module.js:300:12)
>>     at Module.require (module.js:353:17)
>>     at require (internal/module.js:12:17)
>>     at Object.<anonymous> (/opt/superdesk/client/tasks/options/webpack-dev-server.js:4:18)
>>     at Module._compile (module.js:409:26)
>>     at Object.Module._extensions..js (module.js:416:10)
>>     at Module.load (module.js:343:32)
>>     at Function.Module._load (module.js:300:12)
>>     at Module.require (module.js:353:17)
>>     at require (internal/module.js:12:17)
>>     at module.exports (/opt/superdesk/client/node_modules/load-grunt-config/lib/readfile.js:28:16)
>>     at /opt/superdesk/client/node_modules/load-grunt-config/lib/readconfigdir.js:25:18
```
Adding 'use strict' solves the issue.
