### PR TITLE
LBSD-1434 Scorecards unnecessary confirmation popup

### DIFF
--- a/client/app/scripts/liveblog-edit/views/scorecards.html
+++ b/client/app/scripts/liveblog-edit/views/scorecards.html
@@ -104,7 +104,7 @@
             </div>
             <div>
                 <label for="home.score" hide-render>Score</label>
-                <input id="home.score" name="$home.score" class="team-score" number="true" necessary="true" initial="0" />
+                <input id="home.score" name="$home.score" class="team-score" number="true" necessary="true"/>
             </div>
         </fieldset>
         <fieldset>
@@ -132,7 +132,7 @@
             </div>
             <div>
                 <label for="away.score" hide-render>Score</label>
-                <input id="away.score" name="$away.score" class="team-score" necessary="true" initial="0" number="true" />
+                <input id="away.score" name="$away.score" class="team-score" necessary="true" number="true"/>
             </div>
         </fieldset>
 

--- a/client/spec/editor_scorecards_spec.js
+++ b/client/spec/editor_scorecards_spec.js
@@ -26,9 +26,9 @@ describe('Scorecards Posts', function() {
             //check that edit is loading the initial values
             //usign getAttribute('value') instead of getText() because of known webdriver quirk
             expect(editor.homeName.getAttribute('value')).toEqual(data.homeName);
-            expect(editor.homeScore.getAttribute('value')).toEqual('0' + data.homeScore);
+            expect(editor.homeScore.getAttribute('value')).toEqual(data.homeScore);
             expect(editor.awayName.getAttribute('value')).toEqual(data.awayName);
-            expect(editor.awayScore.getAttribute('value')).toEqual('0' + data.awayScore);
+            expect(editor.awayScore.getAttribute('value')).toEqual(data.awayScore);
             expect(editor.player1Name.getAttribute('value')).toEqual(data.player1Name);
             expect(editor.player1Time.getAttribute('value')).toEqual(data.player1Time);
 


### PR DESCRIPTION
When changing from an unchanged/unsaved scorecard there should not be a
confirmation popup