### PR TITLE
fix: instagram `original_id` don't need to contain slash.

### DIFF
--- a/server/liveblog/items/items.py
+++ b/server/liveblog/items/items.py
@@ -108,7 +108,7 @@ class ItemsService(ArchiveService):
             re.compile('https?://(www\.)?youtu\.be/(?P<original_id>[a-zA-Z0-9_-]+)')
         ],
         'instagram': [
-            re.compile('https?://(www\.)?instagr(?:\.am|am\.com)/p/(?P<original_id>.+)')
+            re.compile('https?://(www\.)?instagr(?:\.am|am\.com)/p/(?P<original_id>[^/]+)')
         ],
         'facebook': [
             re.compile('https?://(www\.)?facebook.com/(?P<original_id>.*)')


### PR DESCRIPTION
### fixed
- `original_id` for instagram doesn't need to contain the trailing slash.