### PR TITLE
Add support for relative date format

### DIFF
--- a/server/liveblog/themes/template/filters.py
+++ b/server/liveblog/themes/template/filters.py
@@ -16,6 +16,7 @@ def moment_date_filter_container(theme):
         :return: str
         """
         settings = theme.get('settings', {})
+        locale = settings.get('language', 'en')
         parsed = arrow.get(date)
 
         if not format:
@@ -27,9 +28,16 @@ def moment_date_filter_container(theme):
         elif re.search('l+', format.lower()):
             format = DEFAULT_THEME_DATE_FORMAT
 
-        formated = parsed.to(DEFAULT_THEME_TIMEZONE).format(DEFAULT_THEME_DATE_FORMAT)
+        if format == 'ago':
+            formated = parsed.humanize()
+        else:
+            formated = parsed.to(DEFAULT_THEME_TIMEZONE).format(DEFAULT_THEME_DATE_FORMAT)
+
         try:
-            formated = parsed.to(DEFAULT_THEME_TIMEZONE).format(format, locale=settings.get('language', 'en'))
+            if format == 'ago':
+                formated = parsed.humanize(locale=locale)
+            else:
+                formated = parsed.to(DEFAULT_THEME_TIMEZONE).format(format, locale=locale)
         except Exception:
             logger.info("language not supported")
 


### PR DESCRIPTION
I want to support relative dates in AMP templates too, so the idea is to enable something like `{{ postDate | date('ago') }}`. You already support this format for templates parsed by nunjucks, see https://github.com/liveblog/liveblog/blob/9c134ec1538f3fd58050c043d7cea44f8bb9471e/server/liveblog/themes/themes_assets/default/js/theme/helpers.js#L13-L15