### PR TITLE
feature: add <amp-timeago> for relative dates

### DIFF
--- a/server/liveblog/blogs/templates/embed_amp.html
+++ b/server/liveblog/blogs/templates/embed_amp.html
@@ -23,6 +23,7 @@
     <script async custom-element="amp-image-lightbox" src="https://cdn.ampproject.org/v0/amp-image-lightbox-0.1.js"></script>
     <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>
     <script async custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js"></script>
+    <script async custom-element="amp-timeago" src="https://cdn.ampproject.org/v0/amp-timeago-0.1.js"></script>
     <!-- google analytics -->
     {% if settings.gaCode %}
     <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>


### PR DESCRIPTION
Support relative dates (like "a minute ago") in AMP templates.