### PR TITLE
Travis embedly key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
         - MAIL_USE_SSL=0
         - MAIL_DEBUG=1
         - MAIL_SUPPRESS_SEND=True
-        - secure: Ik9/slkC4NdMOKvH1Cf6Nu+iPFaJZNVvSDn0JMAqTORw2CTMLQhKUQuCUR8sYucr8JMAg2+EGf/kyN13IR32DHbFX/5w/QedJtuN/wl+VxWz1nAhDq8A+UwLkIVH+g9kmVJyYogxH3inouYRa0pKmV0D1B4ju1SlpKD4XSjceeM=
+        - secure: fPxVS405GPTH3QJyEHpRmrRZiA1XT9CNccOQk9Ba4DwElyu1qPCoFspeKHctTas/q+1LURkBfkftkwEx83AEA4HMh0lXuWIR+Cj6B1XuCInkiev8dDh6hcfiDsa5ERuXQSc+DYuThhHhATl1ukpWhFL+dNYyyzixbgBORudc+CU=
 
 services:
     - mongodb

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ env:
         - MAIL_USE_SSL=0
         - MAIL_DEBUG=1
         - MAIL_SUPPRESS_SEND=True
+        - secure: Ik9/slkC4NdMOKvH1Cf6Nu+iPFaJZNVvSDn0JMAqTORw2CTMLQhKUQuCUR8sYucr8JMAg2+EGf/kyN13IR32DHbFX/5w/QedJtuN/wl+VxWz1nAhDq8A+UwLkIVH+g9kmVJyYogxH3inouYRa0pKmV0D1B4ju1SlpKD4XSjceeM=
 
 services:
     - mongodb


### PR DESCRIPTION
This implements our official embedly key encrypted in travis.yml file in order to allow future PRs from fork repositories. Please merge ;)

ps. I think after merging this PR all the other opened PRs should run their tests correctly