### PR TITLE
LBSD-2177 fix: Instagram embeds are not working

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -83,7 +83,7 @@
     "angular": "1.6.9",
     "angular-animate": "1.6.1",
     "angular-contenteditable": "0.3.9",
-    "angular-embed": "^2.1.1",
+    "angular-embed": "eos87/angular-embed",
     "angular-embedly": "Urigo/angular-embedly#0.0.8",
     "angular-gettext": "2.3.10",
     "angular-messages": "1.6.6",


### PR DESCRIPTION
I'm pointing temporarily to until official is updated with the PR I opened to fix this issue superdesk/angular-embed#8

Expecting to change this package url before release 3.4 version
This is also related to #1144