### PR TITLE
LBSD-2177 fix: using forked version of superdesk 1.17.0 to fix instagram

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -112,7 +112,7 @@
     "raven-js": "3.22.3",
     "sanitize-html": "^1.18.2",
     "sir-trevor": "liveblog/sir-trevor-js",
-    "superdesk-core": "superdesk/superdesk-client-core#v1.17.0"
+    "superdesk-core": "eos87/superdesk-client-core#angular-embed-latest"
   },
   "engines": {
     "node": ">=6.6.0 <7.0.0",


### PR DESCRIPTION
embed issues

I ended up forking superdesk-client-core and updating angular-embed dependency in order to fix instagram issues