### PR TITLE
LBSD-2185 Small changes to Simple theme to enable it in generator

### DIFF
--- a/server/liveblog/themes/themes_assets/simple/README.md
+++ b/server/liveblog/themes/themes_assets/simple/README.md
@@ -1,0 +1,34 @@
+# Liveblog SEO Simple Theme
+
+Liveblog SEO Simple Theme based on Liveblog 3 SEO Theme.
+
+## Compatibility
+This theme requires Live Blog version 3.3 or higher.
+
+## Supported features and post types
+TODO
+
+## Develop
+
+The best starting point for the development of custom theme extensions is our Wiki: https://wiki.sourcefabric.org/x/wICrB
+
+--
+
+Just issue a `npm i` followed by `gulp watch-static`.
+
+CSS assets are included in main `index.html` as inline html as AMP doesn't allow
+to include any external CSS or Javascript File.
+
+Development server is listening by default to `localhost:8008`.
+
+## Build
+
+Use `make` or alternatively zip this directory without the `node_modules` and `.git` folders.
+
+## Documentation
+
+Generate documentation via `jsdoc`.
+
+## License
+
+Liveblog 3 is licensed under AGPL v3, as is this theme.

--- a/server/liveblog/themes/themes_assets/simple/package.json
+++ b/server/liveblog/themes/themes_assets/simple/package.json
@@ -1,13 +1,17 @@
 {
-  "name": "simple",
-  "version": "0.0.2",
-  "description": "LB SEO Simple Theme",
+  "name": "liveblog-simple-theme",
+  "version": "0.1.2",
+  "description": "Liveblog SEO Simple Theme",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "author": "",
+  "author": "Aleksandar Backo Jelicic <aleksandar.jelicic@sourcefabric.org>",
   "license": "AGPL-3.0",
   "dependencies": {
     "liveblog-default-theme": "latest"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/liveblog/liveblog/tree/devel/server/liveblog/themes/themes_assets/simple"
   }
 }

--- a/server/liveblog/themes/themes_assets/simple/theme.json
+++ b/server/liveblog/themes/themes_assets/simple/theme.json
@@ -1,7 +1,7 @@
 {
     "label": "LB SEO Simple Theme",
     "name": "simple",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "seoTheme": true,
     "extends": "default",
     "license": "AGPL-3.0",


### PR DESCRIPTION
I also published the theme to npmjs.com in order to make it available in generator. https://www.npmjs.com/package/liveblog-simple-theme
We should republish after merging this.