### PR TITLE
LBSD-2196 fix: hide language option from user's profile

### DIFF
--- a/client/app/styles/sass/liveblog.scss
+++ b/client/app/styles/sass/liveblog.scss
@@ -146,9 +146,13 @@
     line-height: 1.4;
 }
 
-// Remove language options from general and blog settings
-// because the feature is not implemented yet
-// FIXME: must be uncommented after release (LBSD-546)
+// Remove language option form users profile
+// https://dev.sourcefabric.org/browse/LBSD-2196
+.profile-info {
+	div.field__language {
+		display: none;
+	}
+}
 
 //Hide liveblog tab in global settings
 :not(.blog-settings-view)>.settings-page>.tabbable.outer>.nav-stacked {

--- a/client/package.json
+++ b/client/package.json
@@ -112,7 +112,7 @@
     "raven-js": "3.22.3",
     "sanitize-html": "^1.18.2",
     "sir-trevor": "liveblog/sir-trevor-js",
-    "superdesk-core": "eos87/superdesk-client-core#angular-embed-latest"
+    "superdesk-core": "github:eos87/superdesk-client-core#v1.17.0-liveblog"
   },
   "engines": {
     "node": ">=6.6.0 <7.0.0",


### PR DESCRIPTION
The rest of the things were already adjusted in main `superdesk-client-core` repo. This is related to superdesk/superdesk-client-core#2320