### PR TITLE
fix: don’t load deleted posts when toggling highlighted

### DIFF
--- a/server/liveblog/themes/themes_assets/default/js/theme/handlers.js
+++ b/server/liveblog/themes/themes_assets/default/js/theme/handlers.js
@@ -90,7 +90,7 @@ var buttons = {
 
       highlightButton.classList.toggle('header-bar__highlight--active');
       LB.settings.onlyHighlighted = !LB.settings.onlyHighlighted;
-      return viewmodel.loadPosts()
+      return viewmodel.loadPosts({notDeleted: true})
         .then(view.renderTimeline)
         .then(view.displayNewPosts)
         .catch(catchError);


### PR DESCRIPTION
my try to fix #1179