### PR TITLE
LBSD-2278 Fixes deleting bug when blog posts_limit has been reached

### DIFF
--- a/client/app/scripts/liveblog-edit/controllers/blog-edit.js
+++ b/client/app/scripts/liveblog-edit/controllers/blog-edit.js
@@ -313,22 +313,25 @@ export default function BlogEditController(
     }
 
     function savingPost(blog) {
-        postsService.savePost(blog._id,
-            $scope.currentPost,
-            getItemsFromEditor(),
-            {post_status: 'open', sticky: $scope.sticky, lb_highlight: $scope.highlight}
-        ).then((post) => {
-            notify.pop();
-            notify.info(gettext('Post saved'));
+        let postParams = {
+            post_status: 'open',
+            sticky: $scope.sticky,
+            lb_highlight: $scope.highlight,
+        };
 
-            cleanEditor();
-            $scope.selectedPostType = 'Default';
-            $scope.actionPending = false;
-        }, () => {
-            notify.pop();
-            notify.error(gettext('Something went wrong. Please try again later'));
-            $scope.actionPending = false;
-        });
+        postsService.savePost(blog._id, $scope.currentPost, getItemsFromEditor(), postParams)
+            .then((post) => {
+                notify.pop();
+                notify.info(gettext('Post saved'));
+
+                cleanEditor();
+                $scope.selectedPostType = 'Default';
+                $scope.actionPending = false;
+            }, () => {
+                notify.pop();
+                notify.error(gettext('Something went wrong. Please try again later'));
+                $scope.actionPending = false;
+            });
     }
 
     getFreetypes();
@@ -516,32 +519,12 @@ export default function BlogEditController(
                     saveScorers().then(() => {
                         // no need to show anything on success
                     }, () => {
-                        notify.error(gettext('Something went wrong with scoarers status. Please try again later'));
+                        notify.error(gettext('Something went wrong with scorers status. Please try again later'));
                     });
                 }
+
                 notify.info(gettext('Saving post'));
-                const getAllposts = $scope.blogEdit.timelineInstance.pagesManager.allPosts();
-
-                const filtered = getAllposts.filter((el) => el.lb_highlight == false && el.sticky == false);
-
-                if (blog.posts_limit != 0 && blog.total_posts >= blog.posts_limit) {
-                    const deleted = {deleted: true};
-                    const post = filtered[(filtered.length - 1)];
-
-                    postsService.savePost(post.blog, post, [], deleted).then((message) => {
-                        $rootScope.$broadcast('removing_timeline_post', {post: post});
-                        notify.pop();
-                        notify.info(gettext('Wait! saving post'));
-                        $timeout(() => {
-                            savingPost(blog);
-                        }, 1000);
-                    }, () => {
-                        notify.pop();
-                        notify.error(gettext('Something went wrong'));
-                    });
-                } else {
-                    savingPost(blog);
-                }
+                savingPost(blog);
                 blog.total_posts += 1;
             });
         },

--- a/server/liveblog/blogs/embeds.py
+++ b/server/liveblog/blogs/embeds.py
@@ -208,7 +208,7 @@ def embed(blog_id, theme=None, output=None, api_host=None):
             api_host=api_host
         )
 
-    async = theme.get('asyncTheme', False)
+    asyncTheme = theme.get('asyncTheme', False)
     api_host = api_host.replace('//', app.config.get('EMBED_PROTOCOL')) if api_host.startswith('//') else api_host
     api_host = api_host.replace('http://', app.config.get('EMBED_PROTOCOL'))
 
@@ -221,7 +221,7 @@ def embed(blog_id, theme=None, output=None, api_host=None):
         'template': template_content,
         'debug': app.config.get('LIVEBLOG_DEBUG'),
         'assets_root': assets_root,
-        'async': async,
+        'async': asyncTheme,
         'i18n': i18n
     }
     if is_amp:

--- a/server/liveblog/posts/posts.py
+++ b/server/liveblog/posts/posts.py
@@ -240,7 +240,8 @@ class PostsService(ArchiveService):
                 out_service.send_syndication_post(doc, action='created')
 
             # let's check for posts limits in blog and remove old one if needed
-            check_limit_and_delete_oldest(blog_id)
+            if blog_id:
+                check_limit_and_delete_oldest(blog_id)
 
         # send notifications
         push_notification('posts', created=True, post_status=doc['post_status'], posts=posts)

--- a/server/liveblog/posts/posts.py
+++ b/server/liveblog/posts/posts.py
@@ -15,6 +15,7 @@ from superdesk.errors import SuperdeskApiError
 from superdesk import get_resource_service
 from liveblog.common import check_comment_length
 
+from ..blogs.utils import check_limit_and_delete_oldest
 from .tasks import update_post_blog_data, update_post_blog_embed
 
 
@@ -226,7 +227,8 @@ class PostsService(ArchiveService):
                     post['auto_publish'] = synd_in.get('auto_publish')
 
             posts.append(post)
-            app.blog_cache.invalidate(doc.get('blog'))
+            blog_id = doc.get('blog')
+            app.blog_cache.invalidate(blog_id)
 
             # Update blog post data and embed for SEO-enabled blogs.
             update_post_blog_data.delay(doc, action='created')
@@ -236,6 +238,9 @@ class PostsService(ArchiveService):
             if doc['post_status'] == 'open':
                 logger.info('Send document to consumers (if syndicated): {}'.format(doc['_id']))
                 out_service.send_syndication_post(doc, action='created')
+
+            # let's check for posts limits in blog and remove old one if needed
+            check_limit_and_delete_oldest(blog_id)
 
         # send notifications
         push_notification('posts', created=True, post_status=doc['post_status'], posts=posts)
@@ -311,10 +316,6 @@ class PostsService(ArchiveService):
             out_service.send_syndication_post(original, action='deleted')
             # Push notification.
             push_notification('posts', deleted=True, post_id=original.get('_id'))
-        # NOTE: Seems unsused, to be removed later if no bug appears.
-        # elif updates.get('post_status') == 'draft':
-        #     push_notification('posts', drafted=True, post_id=original.get('_id'),
-        #                       author_id=original.get('original_creator'))
         else:
             # Update blog post data and embed for SEO-enabled blogs.
             update_post_blog_data.delay(doc, action='updated')

--- a/server/setup.cfg
+++ b/server/setup.cfg
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length=120
 exclude=env,bin,lib,include,src
-ignore=F811
+ignore=F811,W605,W503,W504


### PR DESCRIPTION
The problem was that the post taken for deletion was the oldest loaded in the timeline (browser side), that caused the removing of recent posts.
Instead of taking the one from timeline we must query the oldest one in database for the current blog and mark it as deleted.