### PR TITLE
cross-plattform path seperator in template.js

### DIFF
--- a/server/liveblog/themes/themes_assets/default/tasks/templates.js
+++ b/server/liveblog/themes/themes_assets/default/tasks/templates.js
@@ -17,7 +17,7 @@ const precompileParentTemplates = (theme, nunjucksEnv) => {
 
   const pathsTuples = discoverThemePaths(theme, '');
   const getPrefix = (filepath) => {
-    const themeBase = filepath.split('/templates/')[0];
+    const themeBase = filepath.split(`${path.sep}templates${path.sep}`)[0];
     return pathsTuples.find(x => x[1] === themeBase)[0];
   }
 


### PR DESCRIPTION
Fixed cross-platform path separator problem