### PR TITLE
Revert "Bump angular from 1.6.9 to 1.7.9 in /client"

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -87,7 +87,7 @@
   },
   "dependencies": {
     "adblock-detect": "1.0.5",
-    "angular": "1.7.9",
+    "angular": "1.6.9",
     "angular-animate": "1.6.1",
     "angular-contenteditable": "0.3.9",
     "angular-embed": "superdesk/angular-embed#9894333",


### PR DESCRIPTION
Reverts liveblog/liveblog#1274 because tests are not ready for this version of angular