### PR TITLE
LBSD-2458 Updated classic theme to use output post endpoint

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -99,5 +99,5 @@ jobs:
         /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1920x1080x24
         export CHROME_BIN=`which google-chrome`
         $CHROME_BIN --version
-        CHROMEDRIVER_VERSION=80.0.3987.106 npm run webdriver-update
+        CHROMEDRIVER_VERSION=83.0.4103.39 npm run webdriver-update
         npm run e2e

--- a/server/liveblog/themes/themes_assets/angular/liveblog-embed/resources.service.js
+++ b/server/liveblog/themes/themes_assets/angular/liveblog-embed/resources.service.js
@@ -159,7 +159,7 @@
             }
             return obj;
         }
-        return $resource(config.api_host + 'api/client_blogs/:blogId/posts', {blogId: config.blog._id}, {
+        return $resource(config.api_host + 'api/client_blogs/' + (window.LB.output ? window.LB.output._id + '/' : '') + ':blogId/posts', {blogId: config.blog._id}, {
             get: {
                 transformResponse: function(posts) {
                     // decode json

--- a/server/liveblog/themes/themes_assets/angular/liveblog-embed/resources.service.js
+++ b/server/liveblog/themes/themes_assets/angular/liveblog-embed/resources.service.js
@@ -159,7 +159,7 @@
             }
             return obj;
         }
-        return $resource(config.api_host + 'api/client_blogs/' + (window.LB.output ? window.LB.output._id + '/' : '') + ':blogId/posts', {blogId: config.blog._id}, {
+        return $resource(config.api_host + 'api/client_blogs/:blogId/' + (window.LB.output ? window.LB.output._id + '/' : '') + 'posts', {blogId: config.blog._id}, {
             get: {
                 transformResponse: function(posts) {
                     // decode json


### PR DESCRIPTION
Classic theme is filtering tagged content sending an ElasticSearch query from the frontend. Now we have updated classic theme to use new endpoint for output channels posts to filter tagged content.  