### PR TITLE
[LBSD 2764] - Connect the backend with frontend components for Polls feature

### DIFF
--- a/client/app/scripts/liveblog-edit/components/polls/poll-component-create.tsx
+++ b/client/app/scripts/liveblog-edit/components/polls/poll-component-create.tsx
@@ -1,7 +1,9 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import './poll-component.scss';
 
-export const PollComponentCreate: React.FunctionComponent<{}> = () => {
+export const PollComponentCreate: React.FunctionComponent<{
+    onFormPopulated: (data: any) => void
+}> = ({ onFormPopulated }) => {
     const [question, setQuestion] = useState<string>('');
     const [options, setOptions] = useState<string[]>(['', '']);
     const [days, setDays] = useState<number>(1);
@@ -31,6 +33,37 @@ export const PollComponentCreate: React.FunctionComponent<{}> = () => {
         setHours(0);
         setMinutes(0);
     };
+
+    const isFormFilled = () => {
+        return question !== '' && options.every((option) => option != '') && (days > 0 || hours > 0 || minutes > 0);
+    };
+
+    const getPollBody = () => {
+        const futureTime = new Date();
+
+        futureTime.setDate(futureTime.getDate() + days);
+        futureTime.setHours(futureTime.getHours() + hours);
+        futureTime.setMinutes(futureTime.getMinutes() + minutes);
+
+        const pollBody = {
+            question: question,
+            answers: options.map((option) => ({
+                option: option,
+                votes: 0,
+            })),
+            active_until: futureTime.toISOString(),
+        };
+
+        return pollBody;
+    };
+
+    useEffect(() => {
+        if (isFormFilled()) {
+            const pollBody = getPollBody();
+
+            onFormPopulated(pollBody);
+        }
+    }, [question, options, days, hours, minutes]);
 
     return (
         <div className="poll_component poll_column poll_gap_16">
@@ -84,7 +117,7 @@ export const PollComponentCreate: React.FunctionComponent<{}> = () => {
                             type="number"
                             min={0}
                             value={days}
-                            onChange={(e) => setDays(parseInt(e.target.value, 10))}
+                            onChange={(e) => setDays(parseInt(e.target.value, 10) || 0)}
                         />
                     </div>
 
@@ -95,7 +128,7 @@ export const PollComponentCreate: React.FunctionComponent<{}> = () => {
                             type="number"
                             min={0}
                             value={hours}
-                            onChange={(e) => setHours(parseInt(e.target.value, 10))}
+                            onChange={(e) => setHours(parseInt(e.target.value, 10) || 0)}
                         />
                     </div>
 
@@ -106,7 +139,7 @@ export const PollComponentCreate: React.FunctionComponent<{}> = () => {
                             type="number"
                             min={0}
                             value={minutes}
-                            onChange={(e) => setMinutes(parseInt(e.target.value, 10))}
+                            onChange={(e) => setMinutes(parseInt(e.target.value, 10) || 0)}
                         />
                     </div>
 

--- a/client/app/scripts/liveblog-edit/components/polls/poll-component-create.tsx
+++ b/client/app/scripts/liveblog-edit/components/polls/poll-component-create.tsx
@@ -6,39 +6,50 @@ interface IProps {
     onFormPopulated: (data: any) => void
 }
 
+interface Answers {
+    option: string;
+    votes: number;
+}
+
 export const PollComponentCreate: React.FunctionComponent<IProps> = ({ item, onFormPopulated }) => {
     const [question, setQuestion] = useState<string>('');
-    const [options, setOptions] = useState<string[]>(['', '']);
+    const [answers, setAnswers] = useState<Answers[]>([{ option: '', votes: 0 }, { option: '', votes: 0 }]);
     const [days, setDays] = useState<number>(1);
     const [hours, setHours] = useState<number>(0);
     const [minutes, setMinutes] = useState<number>(0);
 
-    const addOption = (event) => {
+    const addAnswer = (event) => {
         event.preventDefault();
-        setOptions((prev) => [...prev, '']);
+        setAnswers((prev) => [...prev, { option: '', votes: 0 }]);
     };
 
-    const removeOption = (indexToRemove) => {
-        setOptions((prev) => prev.filter((_, index) => index !== indexToRemove));
+    const removeAnswer = (indexToRemove) => {
+        setAnswers((prev) => prev.filter((_, index) => index !== indexToRemove));
     };
 
-    const updateOption = (indexToUpdate, event) => {
-        const newOption = event.target.value;
+    const updateAnswer = (indexToUpdate, event) => {
+        const newAnswer = event.target.value;
 
-        setOptions((prev) => prev.map((option, index) => index === indexToUpdate ? newOption : option));
+        setAnswers((prev) => {
+            return prev.map((answer, index) => {
+                return index === indexToUpdate ? { ...answer, option: newAnswer } : answer;
+            });
+        });
     };
 
     const resetPoll = (event) => {
         event.preventDefault();
         setQuestion('');
-        setOptions(['', '']);
+        setAnswers([{ option: '', votes: 0 }, { option: '', votes: 0 }]);
         setDays(1);
         setHours(0);
         setMinutes(0);
     };
 
     const isFormFilled = () => {
-        return question !== '' && options.every((option) => option != '') && (days > 0 || hours > 0 || minutes > 0);
+        return question !== ''
+            && answers.length >= 2 && answers.every((answer) => answer.option != '')
+            && (days > 0 || hours > 0 || minutes > 0);
     };
 
     const getPollBody = () => {
@@ -50,10 +61,7 @@ export const PollComponentCreate: React.FunctionComponent<IProps> = ({ item, onF
 
         const pollBody = {
             question: question,
-            answers: options.map((option) => ({
-                option: option,
-                votes: 0,
-            })),
+            answers: answers,
             active_until: futureTime.toISOString(),
         };
 
@@ -66,15 +74,15 @@ export const PollComponentCreate: React.FunctionComponent<IProps> = ({ item, onF
 
             onFormPopulated(pollBody);
         }
-    }, [question, options, days, hours, minutes]);
+    }, [question, answers, days, hours, minutes]);
 
     useEffect(() => {
-        const pollBody = item.poll_body;
+        if (item.poll_body) {
+            const pollBody = item.poll_body;
 
-        setQuestion(pollBody.question);
-        setOptions(pollBody.answers.map((answer) => {
-            return answer.option;
-        }));
+            setQuestion(pollBody.question);
+            setAnswers(pollBody.answers);
+        }
     }, [item]);
 
     return (
@@ -94,7 +102,7 @@ export const PollComponentCreate: React.FunctionComponent<IProps> = ({ item, onF
             <div id="poll_options">
                 <p className="poll_component_subtitle">ANSWERS:</p>
                 <div className="poll_flex_box poll_column poll_gap_8">
-                    {options.map((option, index) => {
+                    {answers.map((answer, index) => {
                         return (
                             <div key={index} className="poll_option_container">
                                 <input
@@ -102,19 +110,19 @@ export const PollComponentCreate: React.FunctionComponent<IProps> = ({ item, onF
                                     type="text"
                                     placeholder={`Option ${index + 1}`}
                                     style={{ width: '100%', paddingRight: '30px' }}
-                                    value={option}
-                                    onChange={(e) => updateOption(index, e)}
+                                    value={answer.option}
+                                    onChange={(e) => updateAnswer(index, e)}
                                 />
                                 <span
                                     className="poll_option_remove_container"
-                                    onClick={() => removeOption(index)}
+                                    onClick={() => removeAnswer(index)}
                                 >
                                     <span className="icon-close-small" />
                                 </span>
                             </div>
                         );
                     })}
-                    <button className="poll_option_add_button" onClick={(e) => addOption(e)}>+ Add Option</button>
+                    <button className="poll_option_add_button" onClick={(e) => addAnswer(e)}>+ Add Option</button>
                 </div>
             </div>
 

--- a/client/app/scripts/liveblog-edit/components/polls/poll-component-create.tsx
+++ b/client/app/scripts/liveblog-edit/components/polls/poll-component-create.tsx
@@ -1,9 +1,12 @@
 import React, { useState, useEffect } from 'react';
 import './poll-component.scss';
 
-export const PollComponentCreate: React.FunctionComponent<{
+interface IProps {
+    item: any;
     onFormPopulated: (data: any) => void
-}> = ({ onFormPopulated }) => {
+}
+
+export const PollComponentCreate: React.FunctionComponent<IProps> = ({ item, onFormPopulated }) => {
     const [question, setQuestion] = useState<string>('');
     const [options, setOptions] = useState<string[]>(['', '']);
     const [days, setDays] = useState<number>(1);
@@ -64,6 +67,15 @@ export const PollComponentCreate: React.FunctionComponent<{
             onFormPopulated(pollBody);
         }
     }, [question, options, days, hours, minutes]);
+
+    useEffect(() => {
+        const pollBody = item.poll_body;
+
+        setQuestion(pollBody.question);
+        setOptions(pollBody.answers.map((answer) => {
+            return answer.option;
+        }));
+    }, [item]);
 
     return (
         <div className="poll_component poll_column poll_gap_16">

--- a/client/app/scripts/liveblog-edit/components/polls/poll-component-view.tsx
+++ b/client/app/scripts/liveblog-edit/components/polls/poll-component-view.tsx
@@ -1,5 +1,6 @@
 /* eslint camelcase: "off" */
 import React, { useState, useEffect } from 'react';
+import ReactDOM from 'react-dom';
 import './poll-component.scss';
 import { pollCalculations } from './utils';
 
@@ -16,7 +17,7 @@ interface IProps {
     item: any;
 }
 
-export const PollComponentView: React.FunctionComponent<IProps> = ({ item }) => {
+const PollComponentView: React.FunctionComponent<IProps> = ({ item }) => {
     const [poll, setPoll] = useState<IPollBody>(pollCalculations(item.poll_body));
 
     useEffect(() => {
@@ -61,3 +62,14 @@ export const PollComponentView: React.FunctionComponent<IProps> = ({ item }) => 
         </div>
     );
 };
+
+
+export const destroyPollComponentView = (element: HTMLDivElement) => {
+    ReactDOM.unmountComponentAtNode(element);
+};
+
+const renderPollComponentView = (element: HTMLDivElement, item: any) => {
+    ReactDOM.render(<PollComponentView item={item} />, element);
+};
+
+export default renderPollComponentView;

--- a/client/app/scripts/liveblog-edit/components/polls/poll-component-view.tsx
+++ b/client/app/scripts/liveblog-edit/components/polls/poll-component-view.tsx
@@ -63,7 +63,6 @@ const PollComponentView: React.FunctionComponent<IProps> = ({ item }) => {
     );
 };
 
-
 export const destroyPollComponentView = (element: HTMLDivElement) => {
     ReactDOM.unmountComponentAtNode(element);
 };

--- a/client/app/scripts/liveblog-edit/components/polls/poll-component.tsx
+++ b/client/app/scripts/liveblog-edit/components/polls/poll-component.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import './poll-component.scss';
 import { PollComponentCreate } from './poll-component-create';
-import { PollComponentView } from './poll-component-view';
 
 interface IProps {
     item: any;
@@ -10,11 +9,7 @@ interface IProps {
 }
 
 const PollComponent: React.FunctionComponent<IProps> = ({ item, onFormPopulated }) => {
-    if (item) {
-        return <PollComponentView item={item} />;
-    }
-
-    return <PollComponentCreate onFormPopulated={onFormPopulated} />;
+    return <PollComponentCreate item={item} onFormPopulated={onFormPopulated} />;
 };
 
 export const destroyPollComponent = (element: HTMLDivElement) => {

--- a/client/app/scripts/liveblog-edit/components/polls/poll-component.tsx
+++ b/client/app/scripts/liveblog-edit/components/polls/poll-component.tsx
@@ -6,14 +6,15 @@ import { PollComponentView } from './poll-component-view';
 
 interface IProps {
     item: any;
+    onFormPopulated?: (data: any) => void;
 }
 
-const PollComponent: React.FunctionComponent<IProps> = ({ item }) => {
+const PollComponent: React.FunctionComponent<IProps> = ({ item, onFormPopulated }) => {
     if (item) {
         return <PollComponentView item={item} />;
     }
 
-    return <PollComponentCreate />;
+    return <PollComponentCreate onFormPopulated={onFormPopulated} />;
 };
 
 export const destroyPollComponent = (element: HTMLDivElement) => {
@@ -21,8 +22,8 @@ export const destroyPollComponent = (element: HTMLDivElement) => {
 };
 
 const renderPollComponent = (
-    element: HTMLDivElement, item: any) => {
-    ReactDOM.render(<PollComponent item={item} />, element);
+    element: HTMLDivElement, item: any, onFormPopulated?: () => void) => {
+    ReactDOM.render(<PollComponent item={item} onFormPopulated={onFormPopulated} />, element);
 };
 
 export default renderPollComponent;

--- a/client/app/scripts/liveblog-edit/components/polls/utils.ts
+++ b/client/app/scripts/liveblog-edit/components/polls/utils.ts
@@ -8,27 +8,34 @@ export const pollCalculations: (pollBody: IPollBody) => IPollBody = (pollBody) =
     const timeLeft = Math.ceil(differenceMs / (1000 * 60 * 60 * 24));
     const timeUnit = timeLeft > 1 ? 'Days' : 'Day';
 
-    // To ensure the percentages add up to 100%, perform some maths
-    // Using the Percentage Rounding Error Allocation method
-    const rawPercentages = pollBody.answers.map((answer) => ({
+    let updatedAnswers = pollBody.answers.map((answer) => ({
         ...answer,
-        rawPercentage: totalVotes === 0 ? 0 : (answer.votes / totalVotes) * 100,
+        percentage: totalVotes === 0 ? 0 : Math.round((answer.votes / totalVotes) * 100),
     }));
-    const roundedPercentages = rawPercentages.map((answer) => ({
-        ...answer,
-        percentage: Math.round(answer.rawPercentage),
-    }));
-    const totalPercentage = roundedPercentages.reduce((acc, answer) => acc + answer.percentage, 0);
-    const adjustment = 100 - totalPercentage;
-    const sortedByRemainder = [...roundedPercentages].sort((a, b) =>
-        (b.rawPercentage - Math.floor(b.rawPercentage)) - (a.rawPercentage - Math.floor(a.rawPercentage))
-    );
 
-    for (let i = 0; i < Math.abs(adjustment); i++) {
-        sortedByRemainder[i % sortedByRemainder.length].percentage += Math.sign(adjustment);
+    if (totalVotes > 0) {
+        // To ensure the percentages add up to 100%, perform some maths
+        // Using the Percentage Rounding Error Allocation method
+        const rawPercentages = pollBody.answers.map((answer) => ({
+            ...answer,
+            rawPercentage: totalVotes === 0 ? 0 : (answer.votes / totalVotes) * 100,
+        }));
+        const roundedPercentages = rawPercentages.map((answer) => ({
+            ...answer,
+            percentage: Math.round(answer.rawPercentage),
+        }));
+        const totalPercentage = roundedPercentages.reduce((acc, answer) => acc + answer.percentage, 0);
+        const adjustment = 100 - totalPercentage;
+        const sortedByRemainder = [...roundedPercentages].sort((a, b) =>
+            (b.rawPercentage - Math.floor(b.rawPercentage)) - (a.rawPercentage - Math.floor(a.rawPercentage))
+        );
+
+        for (let i = 0; i < Math.abs(adjustment); i++) {
+            sortedByRemainder[i % sortedByRemainder.length].percentage += Math.sign(adjustment);
+        }
+
+        updatedAnswers = sortedByRemainder.map(({ option, votes, percentage }) => ({ option, votes, percentage }));
     }
-
-    let updatedAnswers = sortedByRemainder.map(({ option, votes, percentage }) => ({ option, votes, percentage }));
 
     updatedAnswers = updatedAnswers.sort((a, b) => b.votes - a.votes);
 

--- a/client/app/scripts/liveblog-edit/controllers/blog-edit.js
+++ b/client/app/scripts/liveblog-edit/controllers/blog-edit.js
@@ -209,7 +209,7 @@ export default function BlogEditController(
 
     // determine if the loaded item is freetype
     function isItemFreetype(itemType) {
-        var regularItemTypes = ['text', 'video', 'image', 'embed', 'quote', 'comment'];
+        var regularItemTypes = ['text', 'video', 'image', 'embed', 'quote', 'comment', 'poll'];
 
         if (regularItemTypes.indexOf(itemType) !== -1) {
             return false;

--- a/client/app/scripts/liveblog-edit/controllers/blog-edit.js
+++ b/client/app/scripts/liveblog-edit/controllers/blog-edit.js
@@ -146,7 +146,11 @@ export default function BlogEditController(
 
                 if (block.type === 'poll') {
                     return {
-                        poll_body: block.meta,
+                        poll_body: {
+                            question: meta.question,
+                            answers: meta.answers,
+                            active_until: meta.active_until,
+                        },
                         item_type: block.type,
                     };
                 }

--- a/client/app/scripts/liveblog-edit/controllers/blog-edit.js
+++ b/client/app/scripts/liveblog-edit/controllers/blog-edit.js
@@ -144,6 +144,13 @@ export default function BlogEditController(
                 if (block.type === 'image' && meta === null)
                     return null;
 
+                if (block.type === 'poll') {
+                    return {
+                        poll_body: block.meta,
+                        item_type: block.type,
+                    };
+                }
+
                 return {
                     group_type: 'default',
                     text: block.text

--- a/client/app/scripts/liveblog-edit/directives/post.js
+++ b/client/app/scripts/liveblog-edit/directives/post.js
@@ -1,3 +1,5 @@
+/* eslint-disable */
+// @ts-nocheck
 import postTpl from 'scripts/liveblog-edit/views/post.ng1';
 
 lbPost.$inject = [
@@ -133,9 +135,16 @@ export default function lbPost(notify, gettext, postsService, modal,
                 isYoutubeAttached: function(post) {
                     return post.items.some((x) => x.item.item_type === 'video');
                 },
+                isPollAttached: function(post) {
+                    return post.items.some((x) => x.item.item_type === 'poll');
+                },
                 askRemovePost: function(post) {
                     let msg = gettext('Are you sure you want to delete the post?');
 
+                    if (scope.isPollAttached(post)) {
+                        msg += '<br />It contains a poll with important data that will be permanently lost if you proceed.';
+                    }
+                    
                     if (scope.isYoutubeAttached(post)) {
                         msg += '<br/>This will NOT remove the video from YouTube\'s account.';
                     }

--- a/client/app/scripts/liveblog-edit/directives/react-directives.ts
+++ b/client/app/scripts/liveblog-edit/directives/react-directives.ts
@@ -42,7 +42,7 @@ export const lbItemPoll = () => {
         link: (scope, element) => {
             const mountPoint = $(element).get(0);
 
-            renderPollComponent(mountPoint, scope.item);
+            renderPollComponent(mountPoint, scope.item, null);
 
             scope.$on('$destroy', () => destroyPollComponent(mountPoint));
         },

--- a/client/app/scripts/liveblog-edit/directives/react-directives.ts
+++ b/client/app/scripts/liveblog-edit/directives/react-directives.ts
@@ -3,7 +3,7 @@ import { render, unmountComponentAtNode } from 'react-dom';
 import { simpleReactDirective } from './react-directives-factory';
 import { DateTimePicker } from '../components/dateTimePicker';
 import { ItemEmbed } from 'liveblog-edit/components/itemEmbed';
-import renderPollComponent, { destroyPollComponent } from '../components/polls/poll-component';
+import renderPollComponentView, { destroyPollComponentView } from '../components/polls/poll-component-view';
 
 export const dateTimePickerDirective = simpleReactDirective(DateTimePicker, ['datetime', 'onChange']);
 
@@ -42,9 +42,9 @@ export const lbItemPoll = () => {
         link: (scope, element) => {
             const mountPoint = $(element).get(0);
 
-            renderPollComponent(mountPoint, scope.item, null);
+            renderPollComponentView(mountPoint, scope.item);
 
-            scope.$on('$destroy', () => destroyPollComponent(mountPoint));
+            scope.$on('$destroy', () => destroyPollComponentView(mountPoint));
         },
     };
 };

--- a/client/app/scripts/liveblog-edit/directives/react-directives.ts
+++ b/client/app/scripts/liveblog-edit/directives/react-directives.ts
@@ -4,6 +4,7 @@ import { simpleReactDirective } from './react-directives-factory';
 import { DateTimePicker } from '../components/dateTimePicker';
 import { ItemEmbed } from 'liveblog-edit/components/itemEmbed';
 import renderPollComponentView, { destroyPollComponentView } from '../components/polls/poll-component-view';
+import _ from 'lodash';
 
 export const dateTimePickerDirective = simpleReactDirective(DateTimePicker, ['datetime', 'onChange']);
 
@@ -39,12 +40,21 @@ export const lbItemPoll = () => {
             item: '=',
         },
 
-        link: (scope, element) => {
+        link: (scope, element, attrs) => {
             const mountPoint = $(element).get(0);
+            const renderPoll = () => {
+                renderPollComponentView(mountPoint, scope.item);
+            };
 
-            renderPollComponentView(mountPoint, scope.item);
+            renderPoll();
 
             scope.$on('$destroy', () => destroyPollComponentView(mountPoint));
+
+            scope.$watch(attrs.item, (next, original) => {
+                if (!_.isEqual(next.poll_body, original.poll_body)) {
+                    renderPoll();
+                }
+            });
         },
     };
 };

--- a/client/app/scripts/liveblog-edit/module.js
+++ b/client/app/scripts/liveblog-edit/module.js
@@ -100,6 +100,10 @@ const app = angular.module('liveblog.edit',
             type: 'http',
             backend: {rel: 'items'},
         });
+        apiProvider.api('polls', {
+            type: 'http',
+            backend: {rel: 'polls'},
+        });
         apiProvider.api('archive', {
             type: 'http',
             backend: {rel: 'archive'},

--- a/client/app/scripts/liveblog-edit/posts.service.ts
+++ b/client/app/scripts/liveblog-edit/posts.service.ts
@@ -307,17 +307,31 @@ const postsService = (api, $q, _userList, session) => {
 
             // save every items
             _.each(items, (itemParam) => {
-                const item = {
-                    blog: blogId,
-                    text: itemParam.text,
-                    meta: itemParam.meta,
-                    group_type: itemParam.group_type,
-                    item_type: itemParam.item_type,
-                    commenter: itemParam.meta && itemParam.meta.commenter,
-                    syndicated_creator: itemParam.syndicated_creator,
-                };
+                switch (itemParam.item_type) {
+                case 'poll': {
+                    const poll = {
+                        blog: blogId,
+                        poll_body: itemParam.poll_body,
+                    };
 
-                dfds.push(api.items.save(item));
+                    dfds.push(api.polls.save(poll));
+                    break;
+                }
+                default: {
+                    const item = {
+                        blog: blogId,
+                        text: itemParam.text,
+                        meta: itemParam.meta,
+                        group_type: itemParam.group_type,
+                        item_type: itemParam.item_type,
+                        commenter: itemParam.meta && itemParam.meta.commenter,
+                        syndicated_creator: itemParam.syndicated_creator,
+                    };
+
+                    dfds.push(api.items.save(item));
+                    break;
+                }
+                }
             });
         }
 
@@ -341,7 +355,14 @@ const postsService = (api, $q, _userList, session) => {
 
                 // update the post reference (links with itemsList)
                 _.each(itemsList, (item) => {
-                    post.groups[1].refs.push({ residRef: item._id });
+                    switch (item.item_type) {
+                    case 'poll':
+                        post.groups[1].refs.push({ residRef: item._id, location: 'polls' });
+                        break;
+                    default:
+                        post.groups[1].refs.push({ residRef: item._id });
+                        break;
+                    }
                 });
             }
 

--- a/client/app/scripts/sir-trevor-blocks/poll-block.js
+++ b/client/app/scripts/sir-trevor-blocks/poll-block.js
@@ -12,15 +12,21 @@ export default function pollBlock(SirTrevor, config) {
         },
         onBlockRender: function() {
             const container = this.$('.st-poll_block');
-
             const onFormPopulated = (data) => {
                 this.getOptions().disableSubmit(false);
                 this.setData(data);
             };
+            let data = this.getData();
 
-            renderPollComponent(container[0], null, onFormPopulated);
+            renderPollComponent(container[0], data, onFormPopulated);
 
             container.closest('.st-block__inner').off('click');
+        },
+        loadData: function(data) {
+            this.setData(data);
+        },
+        focus: function() {
+            this.$('.poll-input').focus();
         },
     });
 }

--- a/client/app/scripts/sir-trevor-blocks/poll-block.js
+++ b/client/app/scripts/sir-trevor-blocks/poll-block.js
@@ -13,7 +13,12 @@ export default function pollBlock(SirTrevor, config) {
         onBlockRender: function() {
             const container = this.$('.st-poll_block');
 
-            renderPollComponent(container[0], null);
+            const onFormPopulated = (data) => {
+                this.getOptions().disableSubmit(false);
+                this.setData(data);
+            };
+
+            renderPollComponent(container[0], null, onFormPopulated);
 
             container.closest('.st-block__inner').off('click');
         },


### PR DESCRIPTION
### Purpose
This PR aims to integrate the UI components for the Editor's interface, developed in [LBSD-2763](https://github.com/liveblog/liveblog/pull/1358), with the backend endpoints implemented in [LBSD-2762](https://github.com/liveblog/liveblog/pull/1357). The goal is to enable the storage and management of polls within the Editor's interface.

### What has changed
- Wired the frontend UI components for polls with the backend endpoints to allow poll management.
- A poll can be created as a single item in a post or be one of several items in a post.
- Enhanced the "delete" warning for items and posts to inform users that deleting an item containing a poll will result in the loss of all associated poll data.

### Steps to test

1. Navigate to the Editor's interface.
2. Click "Add content here" and select Poll. Fill the poll form and submit. The poll will appear on the timeline.
3. The published poll can also be highlighted, pinned, removed, updated, unpublished and saved in contributions and also moved around to change the order.
4. A new poll can also be saved as a draft or scheduled for publishing at a later date.
5. To test the removal warning, click the remove icon on a published post to see the warning.

Resolves: [LBSD-2764]