### PR TITLE
[LBSD-2734] - Comments display a piece of HTML code when viewed in the LB editor

### DIFF
--- a/client/app/scripts/liveblog-bloglist/views/main.ng1
+++ b/client/app/scripts/liveblog-bloglist/views/main.ng1
@@ -105,14 +105,14 @@
                         <dt ng-if="isAdmin()">{{ ::'Theme' | translate }}:</dt>
                         <dd ng-if="isAdmin()">{{ ::blog.blog_preferences.theme }}</dd>
                         <dt>{{ ::'Created' | translate}}:</dt>
-                        <dd><time datetime="{{ blog._created}}">{{ blog._created | reldateAutoUpdate }}</time></dd>
+                        <dd><time datetime="{{ blog._created}}"><span ng-bind-html="blog._created | reldateAutoUpdate"></span></time></dd>
                         <dt>{{ ::'No. of Posts' | translate }}:</dt>
                         <dd>{{ ::blog.total_posts }}</dd>
                         <dl>
                         <dt> {{ :: 'Last updated' | translate }}:</dt>
-                        <dd><time datetime="{{ blog._updated}}">{{ blog._updated | reldateAutoUpdate }}</time></dd>
+                        <dd><time datetime="{{ blog._updated}}"><span ng-bind-html="blog._updated | reldateAutoUpdate"></span></time></dd>
                         <dt> {{ :: 'Last posted' | translate }}:</dt>
-                        <dd><time datetime="{{ blog.last_created_post._updated}}">{{ blog.last_created_post._updated | reldateAutoUpdate }}</time></dd>
+                        <dd><time datetime="{{ blog.last_created_post._updated}}"><span ng-bind-html="blog.last_created_post._updated | reldateAutoUpdate"></span></time></dd>
                         <dd ng-if="blog.posts_count == 0"> No posts yet</dd>
                         <dt> {{ :: 'Syndication' | translate }}:</dt>
                         <dd>
@@ -128,7 +128,7 @@
                             {{ ::'To be deleted' | translate }}:
                         </dt>
                         <dd ng-if="blog.blog_status == 'deleted'" class="text-red">
-                            {{ ::blog.delete_not_before | reldateAutoUpdate }}
+                            <span ng-html-bind="::blog.delete_not_before | reldateAutoUpdate"></span>
                         </dd>
                     </dl>
                 </div>

--- a/client/app/scripts/liveblog-edit/views/post.ng1
+++ b/client/app/scripts/liveblog-edit/views/post.ng1
@@ -38,17 +38,16 @@
                     <div class="inline" ng-if="post.post_status != 'open'">
                         <span class="name">{{ ::post.mainItem.item.user.display_name }}</span>
                         <span ng-if="post.producer_blog_title" class="producer">{{ ::post.producer_blog_title }}</span>
-                        | <time datetime="{{ post._created}}">{{ post._created | reldateAutoUpdate }}</time>
+                        | <time datetime="{{ post._created }}"><span ng-bind-html="post._created | reldateAutoUpdate"></span></time>
                     </div>
                     <div class="inline" ng-if="post.post_status == 'open'">
                         <span class="name">{{ ::post.mainItem.item.user.display_name }}</span>
                         <span ng-if="post.producer_blog_title" class="producer">{{ ::post.producer_blog_title }}</span>
-                        | <time datetime="{{ post.published_date }}" ng-bind-html="post.published_date | reldateAutoUpdate"></time>
+                        | <time datetime="{{ post.published_date }}"><span ng-bind-html="post.published_date | reldateAutoUpdate"></span></time>
                     </div>
                     <div class="inline" ng-if="post.showUpdate">
-                        <span class="updated-label" translate>&nbsp;Updated</span> <time class="updated-time" datetime="{{ post.content_updated_date}}">
-                        {{ post.content_updated_date | reldateAutoUpdate }}
-                    </time>
+                        <span class="updated-label" translate>&nbsp;Updated</span> 
+                        <time class="updated-time" datetime="{{ post.content_updated_date }}"><span ng-bind-html="post.content_updated_date | reldateAutoUpdate"></span></time>
                     </div>
                     <div class="lb-post__actions" ng-if="!postsListCtrl.isBlogClosed">
                         <ul>
@@ -118,7 +117,7 @@
                                         <div class="inline">
                                             <span class="name">{{ ::item.item.user.display_name }}</span>
                                             <span ng-if="post.producer_blog_title" class="producer">{{ ::post.producer_blog_title }}</span>
-                                            | <time datetime="{{ (item.item.meta._created || item.item._created) }}">{{ ::(item.item.meta._created || item.item._created) | reldateAutoUpdate }}</time>
+                                            | <time datetime="{{ (item.item.meta._created || item.item._created) }}"><span ng-bind-html="::(item.item.meta._created || item.item._created) | reldateAutoUpdate"></span></time>
                                         </div>
                                     </div>
                                     <lb-item item="item.item"></lb-item>


### PR DESCRIPTION
### Purpose

This PR fixes a bug where pieces of HTML code are displayed in cases where the `reldateAutoUpdate` filter is used.

### What has changed

- Added the `ng-bind-html` directive where the `reldateAutoUpdate` is used.

### Steps to test
_Note: To reproduce this easily, change the date & time in your computer to something in the past (1 hour or 1 day)._

1. Navigate to the Editor's interface.
2. Click "Add content here" and add any content.
3. Click "Live" to see the Live Preview. Click on "Comment" at the top and add a comment.
4. Navigate back to the Editor's interface and go to the comments section.
5. The comment timestamp should show correctly without HTML code.


### Screenshots

| Original  | New |
| ------------- | ------------- |
| ![image](https://github.com/liveblog/liveblog/assets/14116447/00bc6874-05f5-4af9-ab3d-3f4a4f228702) | ![image](https://github.com/liveblog/liveblog/assets/14116447/e14e1930-345b-4bb1-98d7-508a02510931)   |

This also works in the Blog List page after the time has been turned back as shown 

| Original  | New |
| ------------- | ------------- |
| ![image](https://github.com/liveblog/liveblog/assets/14116447/3f15bde2-25b5-46be-a6a0-9202e1029522) | ![image](https://github.com/liveblog/liveblog/assets/14116447/d3124e86-101f-44f4-9d45-493333a8a60b) |



Resolves: [LBSD-2734](https://sofab.atlassian.net/browse/LBSD-2734)

[LBSD-2734]: https://sofab.atlassian.net/browse/LBSD-2734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ