### PR TITLE
[LBSD-2733] - Refactor `publish_blog_embed_to_s3` task

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -84,7 +84,7 @@ jobs:
         pip install 'pip<=20.2.3'
         pip install 'setuptools<50'
         pip install -r dev-requirements.txt
-        pytest --ignore=src/ -v
+        pytest --ignore=src/ --disable-pytest-warnings -v
         behave --format progress2 --logging-level ERROR
 
     - name: Install Nodejs dependencies and lint

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "liveblog-client",
-  "version": "3.85.0-rc1",
+  "version": "3.85.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1326,10 +1326,6 @@
           "integrity": "sha512-+3YA3hpUsl9lWPPsPQshiyXvU9EgJhvMoG2V74b6D2BddGePqRbQWNztTvpoUjlpf+3TUIL14C4Cad4QNvOVfQ=="
         }
       }
-    },
-    "angular-history": {
-      "version": "github:decipherinc/angular-history#ee798413fba074e3d8f2d35fc951a83cb73e923e",
-      "from": "github:decipherinc/angular-history#v0.8.0"
     },
     "angular-i18n": {
       "version": "1.6.9",
@@ -10387,8 +10383,7 @@
     "json-loader": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.4.tgz",
-      "integrity": "sha512-UR2AoqXOuhwApRPGe9YUuU3ARd2fQ4gfZvCpJjZ2ZrKOrt3+DbLg5QXa1W5rUvdUIuhMHyxniMr+u4bHjWMVYQ==",
-      "dev": true
+      "integrity": "sha512-UR2AoqXOuhwApRPGe9YUuU3ARd2fQ4gfZvCpJjZ2ZrKOrt3+DbLg5QXa1W5rUvdUIuhMHyxniMr+u4bHjWMVYQ=="
     },
     "json-parse-even-better-errors": {
       "version": "2.3.1",
@@ -12331,6 +12326,152 @@
               "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
               "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
             }
+          }
+        }
+      }
+    },
+    "node-sass": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.9.0.tgz",
+      "integrity": "sha512-QFHfrZl6lqRU3csypwviz2XLgGNOoWQbo2GOvtsfQqOfL4cy1BtWnhx/XUeAO9LT3ahBzSRXcEO6DdvAH9DzSg==",
+      "requires": {
+        "async-foreach": "^0.1.3",
+        "chalk": "^1.1.1",
+        "cross-spawn": "^3.0.0",
+        "gaze": "^1.0.0",
+        "get-stdin": "^4.0.1",
+        "glob": "^7.0.3",
+        "in-publish": "^2.0.0",
+        "lodash.assign": "^4.2.0",
+        "lodash.clonedeep": "^4.3.2",
+        "lodash.mergewith": "^4.6.0",
+        "meow": "^3.7.0",
+        "mkdirp": "^0.5.1",
+        "nan": "^2.10.0",
+        "node-gyp": "^3.3.1",
+        "npmlog": "^4.0.0",
+        "request": "~2.79.0",
+        "sass-graph": "^2.2.4",
+        "stdout-stream": "^1.4.0",
+        "true-case-path": "^1.0.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA=="
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+          "integrity": "sha512-8HWGSLAPr+AG0hBpsqi5Ob8HrLStN/LWeqhpFl14d7FJgHK48TmgLoALPz69XSUR65YJzDfLUX/BM8+MLJLghQ==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "gaze": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
+          "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
+          "requires": {
+            "globule": "^1.0.0"
+          }
+        },
+        "globule": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/globule/-/globule-1.3.4.tgz",
+          "integrity": "sha512-OPTIfhMBh7JbBYDpa5b+Q5ptmMWKwcNcFSR/0c6t8V4f3ZAVBEsKNY37QdVqmLRYSMhOUGYrY0QhSoEpzGr/Eg==",
+          "requires": {
+            "glob": "~7.1.1",
+            "lodash": "^4.17.21",
+            "minimatch": "~3.0.2"
+          },
+          "dependencies": {
+            "glob": {
+              "version": "7.1.7",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+              "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            }
+          }
+        },
+        "minimatch": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
+          "integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="
+        },
+        "qs": {
+          "version": "6.3.3",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.3.tgz",
+          "integrity": "sha512-f8CQ/sKJBr9vfNJBdGiPzTSPUufuWyvOFkCYJKN9voqPWuBuhdlSZM78dOHKigtZ0BwuktYGrRFW2DXXc/f2Fg=="
+        },
+        "request": {
+          "version": "2.79.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+          "integrity": "sha512-e7MIJshe1eZAmRqg4ryaO0N9G0fs+/gpDe5FlbnIFy6zZznRSwdRFrLp63if0Yt43vrI5wowOqHv1qJdVocdOQ==",
+          "requires": {
+            "aws-sign2": "~0.6.0",
+            "aws4": "^1.2.1",
+            "caseless": "~0.11.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.0",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.1.1",
+            "har-validator": "~2.0.6",
+            "hawk": "~3.1.3",
+            "http-signature": "~1.1.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.7",
+            "oauth-sign": "~0.8.1",
+            "qs": "~6.3.0",
+            "stringstream": "~0.0.4",
+            "tough-cookie": "~2.3.0",
+            "tunnel-agent": "~0.4.1",
+            "uuid": "^3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g=="
+        },
+        "tough-cookie": {
+          "version": "2.3.4",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+          "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+          "requires": {
+            "punycode": "^1.4.1"
           }
         }
       }
@@ -18185,7 +18326,7 @@
       }
     },
     "superdesk-core": {
-      "version": "github:liveblog/superdesk-client-core#3f7eec9134c9013592cadfb92429ed6e458300d1",
+      "version": "github:liveblog/superdesk-client-core#51e26f399689aa0d739d0acdb058bff7b6618644",
       "from": "github:liveblog/superdesk-client-core#v1.17.0-liveblog",
       "requires": {
         "angular": "1.6.9",
@@ -18194,7 +18335,6 @@
         "angular-embed": "github:superdesk/angular-embed#9894333",
         "angular-embedly": "github:Urigo/angular-embedly#0.0.8",
         "angular-gettext": "2.3.10",
-        "angular-history": "github:decipherinc/angular-history#v0.8.0",
         "angular-i18n": "1.6.9",
         "angular-mocks": "1.6.9",
         "angular-moment": "1.2.0",
@@ -18452,24 +18592,6 @@
             }
           }
         },
-        "form-data": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-          "integrity": "sha512-8HWGSLAPr+AG0hBpsqi5Ob8HrLStN/LWeqhpFl14d7FJgHK48TmgLoALPz69XSUR65YJzDfLUX/BM8+MLJLghQ==",
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.5",
-            "mime-types": "^2.1.12"
-          }
-        },
-        "gaze": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
-          "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
-          "requires": {
-            "globule": "^1.0.0"
-          }
-        },
         "glob": {
           "version": "7.0.6",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
@@ -18499,36 +18621,6 @@
               "requires": {
                 "is-extglob": "^2.1.0"
               }
-            }
-          }
-        },
-        "globule": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/globule/-/globule-1.3.4.tgz",
-          "integrity": "sha512-OPTIfhMBh7JbBYDpa5b+Q5ptmMWKwcNcFSR/0c6t8V4f3ZAVBEsKNY37QdVqmLRYSMhOUGYrY0QhSoEpzGr/Eg==",
-          "requires": {
-            "glob": "~7.1.1",
-            "lodash": "^4.17.21",
-            "minimatch": "~3.0.2"
-          },
-          "dependencies": {
-            "glob": {
-              "version": "7.1.7",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-              "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              }
-            },
-            "lodash": {
-              "version": "4.17.21",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-              "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
             }
           }
         },
@@ -18624,11 +18716,6 @@
             "esprima": "^2.6.0"
           }
         },
-        "json-loader": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
-          "integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w=="
-        },
         "json5": {
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
@@ -18645,32 +18732,6 @@
           "integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
           "requires": {
             "brace-expansion": "^1.1.7"
-          }
-        },
-        "node-sass": {
-          "version": "4.9.0",
-          "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.9.0.tgz",
-          "integrity": "sha512-QFHfrZl6lqRU3csypwviz2XLgGNOoWQbo2GOvtsfQqOfL4cy1BtWnhx/XUeAO9LT3ahBzSRXcEO6DdvAH9DzSg==",
-          "requires": {
-            "async-foreach": "^0.1.3",
-            "chalk": "^1.1.1",
-            "cross-spawn": "^3.0.0",
-            "gaze": "^1.0.0",
-            "get-stdin": "^4.0.1",
-            "glob": "^7.0.3",
-            "in-publish": "^2.0.0",
-            "lodash.assign": "^4.2.0",
-            "lodash.clonedeep": "^4.3.2",
-            "lodash.mergewith": "^4.6.0",
-            "meow": "^3.7.0",
-            "mkdirp": "^0.5.1",
-            "nan": "^2.10.0",
-            "node-gyp": "^3.3.1",
-            "npmlog": "^4.0.0",
-            "request": "~2.79.0",
-            "sass-graph": "^2.2.4",
-            "stdout-stream": "^1.4.0",
-            "true-case-path": "^1.0.2"
           }
         },
         "nopt": {
@@ -18717,16 +18778,6 @@
             "object-assign": "^4.1.1"
           }
         },
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="
-        },
-        "qs": {
-          "version": "6.3.3",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.3.tgz",
-          "integrity": "sha512-f8CQ/sKJBr9vfNJBdGiPzTSPUufuWyvOFkCYJKN9voqPWuBuhdlSZM78dOHKigtZ0BwuktYGrRFW2DXXc/f2Fg=="
-        },
         "react": {
           "version": "16.2.0",
           "resolved": "https://registry.npmjs.org/react/-/react-16.2.0.tgz",
@@ -18747,33 +18798,6 @@
             "loose-envify": "^1.1.0",
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.0"
-          }
-        },
-        "request": {
-          "version": "2.79.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
-          "integrity": "sha512-e7MIJshe1eZAmRqg4ryaO0N9G0fs+/gpDe5FlbnIFy6zZznRSwdRFrLp63if0Yt43vrI5wowOqHv1qJdVocdOQ==",
-          "requires": {
-            "aws-sign2": "~0.6.0",
-            "aws4": "^1.2.1",
-            "caseless": "~0.11.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.0",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.1.1",
-            "har-validator": "~2.0.6",
-            "hawk": "~3.1.3",
-            "http-signature": "~1.1.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.7",
-            "oauth-sign": "~0.8.1",
-            "qs": "~6.3.0",
-            "stringstream": "~0.0.4",
-            "tough-cookie": "~2.3.0",
-            "tunnel-agent": "~0.4.1",
-            "uuid": "^3.0.0"
           }
         },
         "resolve": {
@@ -18817,14 +18841,6 @@
           "integrity": "sha512-Jds2VIYDrlp5ui7t8abHN2bjAu4LV/q4N2KivFPpGH0lrka0BMq/33AmECUXlKPcHigkNaqfXRENFju+rlcy+A==",
           "requires": {
             "has-flag": "^1.0.0"
-          }
-        },
-        "tough-cookie": {
-          "version": "2.3.4",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-          "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
-          "requires": {
-            "punycode": "^1.4.1"
           }
         },
         "webpack-dev-server": {

--- a/server/liveblog/blogs/tasks.py
+++ b/server/liveblog/blogs/tasks.py
@@ -24,6 +24,7 @@ from .app_settings import (
 from .embeds import embed, render_bloglist_embed
 from .exceptions import MediaStorageUnsupportedForBlogPublishing
 from .utils import (
+    build_blog_public_url,
     check_media_storage,
     get_blog_path,
     get_bloglist_path,

--- a/server/liveblog/blogs/tests/utils_test.py
+++ b/server/liveblog/blogs/tests/utils_test.py
@@ -1,0 +1,27 @@
+import pytest
+from ..utils import build_blog_public_url
+
+
+@pytest.fixture
+def mock_app():
+    class MockApp:
+        config = {"SERVER_NAME": "liveblog.pro", "EMBED_PROTOCOL": "https://"}
+
+    return MockApp()
+
+
+def test_build_blog_public_url_with_all_params(mock_app):
+    blog_id = "123"
+    theme = "dark"
+    output_id = "456"
+    expected_url = "https://liveblog.pro/embed/123/456/theme/dark"
+
+    assert build_blog_public_url(mock_app, blog_id, theme, output_id) == expected_url
+
+
+def test_build_blog_public_url_without_output_id(mock_app):
+    blog_id = "123"
+    theme = "light"
+    expected_url = "https://liveblog.pro/embed/123"
+
+    assert build_blog_public_url(mock_app, blog_id, theme) == expected_url

--- a/server/liveblog/blogs/utils.py
+++ b/server/liveblog/blogs/utils.py
@@ -153,3 +153,20 @@ def can_delete_blog(blog):
         return False
 
     return True
+
+
+def build_blog_public_url(app, blog_id, theme, output_id=None):
+    """
+    Creates the public url for a given blog. If `output_id` is provided
+    it will compile the url using the given theme
+    """
+    server_url = app.config["SERVER_NAME"]
+    protocol = app.config["EMBED_PROTOCOL"]
+
+    theme_str = output_str = ""
+
+    if output_id:
+        output_str = f"/{output_id}"
+        theme_str = f"/theme/{theme}" if theme else ""
+
+    return f"{protocol}{server_url}/embed/{blog_id}{output_str}{theme_str}"

--- a/server/liveblog/items/items.py
+++ b/server/liveblog/items/items.py
@@ -126,7 +126,7 @@ class ItemsService(ArchiveService):
         """
         original_url = doc["meta"].get("original_url")
         if not original_url:
-            logger.warning(
+            logger.info(
                 'Unable to find original_url in item "{}" meta.'.format(doc["_id"])
             )
             return

--- a/server/liveblog/items/tests/items_test.py
+++ b/server/liveblog/items/tests/items_test.py
@@ -241,7 +241,7 @@ class ClientModuleTest(TestCase):
     def test_b_set_embed_metadata(self, mock_logger):
         self.item_meta_doc["meta"]["original_url"] = None
         self.items_service.set_embed_metadata(self.item_meta_doc)
-        self.assertTrue(mock_logger.warning.called)
+        self.assertTrue(mock_logger.info.called)
 
     def test_c_item_on_create(self):
         flask.g.user = get_resource_service("users").find_one(

--- a/server/liveblog/posts/tasks.py
+++ b/server/liveblog/posts/tasks.py
@@ -75,7 +75,9 @@ def update_post_blog_embed(post):
     logger.warning('update_post_blog_embed for blog "{}" started.'.format(blog_id))
 
     try:
-        publish_blog_embeds_on_s3(blog_id, save=(blog.get('public_url') is None), safe=True)
+        publish_blog_embeds_on_s3(
+            blog_id, save=(blog.get("public_url") is None), safe=True
+        )
     except (Exception, SoftTimeLimitExceeded):
         logger.exception('update_post_blog_embed for blog "{}" failed.'.format(blog_id))
     finally:

--- a/server/liveblog/posts/tasks.py
+++ b/server/liveblog/posts/tasks.py
@@ -73,8 +73,9 @@ def update_post_blog_embed(post):
         return
 
     logger.warning('update_post_blog_embed for blog "{}" started.'.format(blog_id))
+
     try:
-        publish_blog_embeds_on_s3(blog_id, save=False, safe=True)
+        publish_blog_embeds_on_s3(blog_id, save=(blog.get('public_url') is None), safe=True)
     except (Exception, SoftTimeLimitExceeded):
         logger.exception('update_post_blog_embed for blog "{}" failed.'.format(blog_id))
     finally:

--- a/server/liveblog/themes/themes.py
+++ b/server/liveblog/themes/themes.py
@@ -592,7 +592,7 @@ class ThemesService(BaseService):
         for output in outputs:
             publish_blog_embed_on_s3.apply_async(
                 args=[output.get("blog")],
-                kwargs={"theme": output.get("theme", None), "output": output},
+                kwargs={"output": output},
                 countdown=countdown,
             )
             countdown += step


### PR DESCRIPTION
### Purpose
This the first of two PRs to solve [LBSD-2733]. The second PR will be about giving feedback to client about the failure of generating the embed with the selected theme.

There were a couple of problems that have been fixed in this refactoring. Sometimes the `_publish_blog_embed_on_s3` function was provided without a theme (`None` value) which led to an error while generating the embed. While working on this refactoring I figured out that the theme parameter was really unnecessary therefore it has been removed. Now, to generate the embed, the function would use either the blog's theme or the output channel theme if provided.

The other issue that has been solved is that the `public_url` value of the blog was not being saved after the initial embed generation was processed. If the initial generation failed, no `public_url` was saved and subsequently it was not updated given a wrong logic. Now when the embed is generated and there is no `public_url` assigned, the blog will be updated anytime a new url is generated as part of the embed processing. This partly solves LBSD-2733 as when there is no `public_url` the Live button would not show up. 

### What has changed

- `publish_blog_embed_to_s3` task has been refactored for easier reading and maintainability
- introduced a couple of utility functions to try to declutter the code in this function which was a bit messy
- added some additional tests for such functions
- removed the theme parameter as it was not used (or at least I think it was not ;)) 

### Steps to test

- checkout the branch 
- run the services
- check that the embed generation works without any issues both with the regular blog embed and the output channels

Partly resolves: [LBSD-2733]

[LBSD-2733]: https://sofab.atlassian.net/browse/LBSD-2733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LBSD-2733]: https://sofab.atlassian.net/browse/LBSD-2733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ