### PR TITLE
[LBSD-2782] - Implement new backend structure to store Instance Settings

### DIFF
--- a/server/liveblog/instance_settings/__init__.py
+++ b/server/liveblog/instance_settings/__init__.py
@@ -1,0 +1,12 @@
+import superdesk
+from .instance_settings import (
+    instance_settings_key,
+    InstanceSettingsResource,
+    InstanceSettingsService,
+)
+
+
+def init_app(app):
+    endpoint_name = instance_settings_key
+    service = InstanceSettingsService(endpoint_name, backend=superdesk.get_backend())
+    InstanceSettingsResource(endpoint_name, app=app, service=service)

--- a/server/liveblog/instance_settings/instance_settings.py
+++ b/server/liveblog/instance_settings/instance_settings.py
@@ -38,7 +38,7 @@ class InstanceSettingsService(BaseService):
                 errors = validator._validate_settings(doc["settings"])
                 if errors:
                     abort(
-                        422,
+                        400,
                         description="Validation errors for config occurred: "
                         + ", ".join(errors),
                     )
@@ -59,10 +59,8 @@ class InstanceSettingsService(BaseService):
     def create(self, docs, **kwargs):
         existing_config = self.get_existing_config()
         if existing_config:
-            abort(
-                422,
-                description="Existing config updated. No new config created",
-            )
+            abort(422, description="No new config created. Existing config updated.")
+
         return super().create(docs, **kwargs)
 
     def get_existing_config(self):

--- a/server/liveblog/instance_settings/instance_settings.py
+++ b/server/liveblog/instance_settings/instance_settings.py
@@ -1,0 +1,88 @@
+import logging
+from liveblog.validator import LiveblogValidator
+from superdesk import get_resource_service
+from superdesk.resource import Resource
+from superdesk.services import BaseService
+from flask import abort
+
+instance_settings_key = "instance_settings"
+logger = logging.getLogger(__name__)
+
+
+class InstanceSettingsResource(Resource):
+    """
+    This resources is used to store instance settings for the liveblog instance.
+    The instance settings are stored as a JSON object in the settings field.
+    """
+
+    datasource = {"source": instance_settings_key}
+    schema = {
+        "settings": {
+            "type": "dict",
+            "allow_unknown": True,
+        }
+    }
+
+    item_methods = ["GET"]
+    privileges = {"GET": "posts", "POST": "posts"}
+
+
+class InstanceSettingsService(BaseService):
+    def on_create(self, docs):
+        validator = LiveblogValidator()
+        existing_config = self.get_existing_config()
+
+        for doc in docs:
+            if "settings" in doc:
+                # Validate the configuration to have the required fields
+                errors = validator._validate_settings(doc["settings"])
+                if errors:
+                    abort(
+                        422,
+                        description="Validation errors for config occurred: "
+                        + ", ".join(errors),
+                    )
+                if existing_config:
+                    # If there is an existing config, merge the configs
+                    updated_settings = self.merge_configs(
+                        existing_config.get("settings", {}), doc["settings"]
+                    )
+                    get_resource_service(instance_settings_key).update(
+                        id=existing_config["_id"],
+                        updates={"settings": updated_settings},
+                        original=existing_config,
+                    )
+
+        if existing_config is None:
+            return super().on_create(docs)
+
+    def create(self, docs, **kwargs):
+        existing_config = self.get_existing_config()
+        if existing_config:
+            abort(
+                422,
+                description="Existing config updated. No new config created",
+            )
+        return super().create(docs, **kwargs)
+
+    def get_existing_config(self):
+        """
+        Check if any config exists at all. This assumes the singleton pattern where there
+        exists only one config at a time
+        """
+        existing_configs = list(
+            get_resource_service(instance_settings_key).get(req=None, lookup={})
+        )
+        return existing_configs[0] if existing_configs else None
+
+    def merge_configs(self, original, new):
+        """
+        This function merges the new configuration into the original configuration but does not overwrite existing keys.
+        It adds new keys to the original configuration only if they do not exist.
+        """
+        for key, value in new.items():
+            if key not in original:
+                original[key] = value
+            elif isinstance(original[key], dict) and isinstance(value, dict):
+                original[key] = self.merge_configs(original[key], value)
+        return original

--- a/server/liveblog/prepopulate/data_init/instance_settings.json
+++ b/server/liveblog/prepopulate/data_init/instance_settings.json
@@ -43,7 +43,6 @@
                 "themes": 6,
                 "blog_members": 5
             }
-        },
-        "network": 1
+        }
     }
 }

--- a/server/liveblog/prepopulate/data_init/instance_settings.json
+++ b/server/liveblog/prepopulate/data_init/instance_settings.json
@@ -1,24 +1,48 @@
 {
     "settings": {
-        "uni": {
-            "max_active_blogs": 1,
-            "max_blog_members": 2,
-            "max_themes": 3
-        },
         "one-time-event": {
-            "max_active_blogs": 1,
-            "max_blog_members": 2,
-            "max_themes": 3
+            "features": {
+                "syndication": false,
+                "marketplace": false
+            },
+            "limits": {
+                "blogs": 1,
+                "themes": 1,
+                "blog_members": 2
+            }
+        },
+        "uni": {
+            "features": {
+                "syndication": true,
+                "marketplace": false
+            },
+            "limits": {
+                "blogs": 1,
+                "themes": 2,
+                "blog_members": 3
+            }
         },
         "solo": {
-            "max_active_blogs": 1,
-            "max_blog_members": 2,
-            "max_themes": 3
+            "features": {
+                "syndication": true,
+                "marketplace": false
+            },
+            "limits": {
+                "blogs": 1,
+                "themes": 1,
+                "blog_members": 1
+            }
         },
         "team": {
-            "max_active_blogs": 3,
-            "max_blog_members": 4,
-            "max_themes": 6
+            "features": {
+                "syndication": true,
+                "marketplace": true
+            },
+            "limits": {
+                "blogs": 3,
+                "themes": 6,
+                "blog_members": 5
+            }
         },
         "network": 1
     }

--- a/server/liveblog/prepopulate/data_init/instance_settings.json
+++ b/server/liveblog/prepopulate/data_init/instance_settings.json
@@ -1,0 +1,25 @@
+{
+    "settings": {
+        "uni": {
+            "max_active_blogs": 1,
+            "max_blog_members": 2,
+            "max_themes": 3
+        },
+        "one-time-event": {
+            "max_active_blogs": 1,
+            "max_blog_members": 2,
+            "max_themes": 3
+        },
+        "solo": {
+            "max_active_blogs": 1,
+            "max_blog_members": 2,
+            "max_themes": 3
+        },
+        "team": {
+            "max_active_blogs": 3,
+            "max_blog_members": 4,
+            "max_themes": 6
+        },
+        "network": 1
+    }
+}

--- a/server/liveblog/validator.py
+++ b/server/liveblog/validator.py
@@ -89,3 +89,36 @@ class LiveblogValidator(SuperdeskValidator):
                             response.status_code
                         ),
                     )
+
+    def _validate_settings(self, settings):
+        errors = []
+        required_schema = {
+            "max_active_blogs": {"type": "integer", "min": 1, "required": True},
+            "max_blog_members": {"type": "integer", "min": 1, "required": True},
+            "max_themes": {"type": "integer", "min": 1, "required": True},
+        }
+
+        for key, value in settings.items():
+            if key == "network":
+                # Special case for 'network' plan
+                if not isinstance(value, int) or value < 1:
+                    errors.append(
+                        f"The value for '{key}' must be an integer and at least 1."
+                    )
+            else:
+                # General case for other plans
+                if not isinstance(value, dict):
+                    errors.append(f"The value for '{key}' must be a dictionary.")
+                else:
+                    for field, attrs in required_schema.items():
+                        if field not in value:
+                            errors.append(f"Missing '{field}' in settings for '{key}'.")
+                        elif (
+                            not isinstance(value[field], int)
+                            or value[field] < attrs["min"]
+                        ):
+                            errors.append(
+                                f"The '{field}' for '{key}' must be an integer and at least {attrs['min']}."
+                            )
+
+        return errors

--- a/server/liveblog/validator.py
+++ b/server/liveblog/validator.py
@@ -105,35 +105,27 @@ class LiveblogValidator(SuperdeskValidator):
         }
 
         for key, config in settings.items():
-            if key == "network":
-                # Special case for 'network' plan
-                if not isinstance(config, int) or config < 1:
-                    errors.append(
-                        f"The value for '{key}' must be an integer and at least 1."
-                    )
-            else:
-                # General case for other plans
-                for section, section_config in required_schema.items():
-                    if section not in config:
-                        errors.append(f"Missing '{section}' in settings for '{key}'.")
-                    else:
-                        for field, field_attrs in section_config.items():
-                            if field not in config[section]:
+            for section, section_config in required_schema.items():
+                if section not in config:
+                    errors.append(f"Missing '{section}' in settings for '{key}'.")
+                else:
+                    for field, field_attrs in section_config.items():
+                        if field not in config[section]:
+                            errors.append(
+                                f"Missing '{field}' in '{section}' for '{key}'."
+                            )
+                        else:
+                            field_value = config[section][field]
+                            if not isinstance(field_value, field_attrs["type"]):
                                 errors.append(
-                                    f"Missing '{field}' in '{section}' for '{key}'."
+                                    f"The '{field}' in '{section}' for '{key}' must be a {field_attrs['type']}."
                                 )
-                            else:
-                                field_value = config[section][field]
-                                if not isinstance(field_value, field_attrs["type"]):
-                                    errors.append(
-                                        f"The '{field}' in '{section}' for '{key}' must be a {field_attrs['type']}."
-                                    )
-                                if (
-                                    field_attrs["type"] == int
-                                    and field_value < field_attrs["min"]
-                                ):
-                                    errors.append(
-                                        f"The '{field}' in '{section}' for '{key}' must be at least {field_attrs['min']}."
-                                    )
+                            if (
+                                field_attrs["type"] == int
+                                and field_value < field_attrs["min"]
+                            ):
+                                errors.append(
+                                    f"The '{field}' in '{section}' for '{key}' must be at least {field_attrs['min']}."
+                                )
 
         return errors

--- a/server/settings.py
+++ b/server/settings.py
@@ -195,6 +195,7 @@ INSTALLED_APPS = [
     "liveblog.analytics",
     "liveblog.advertisements",
     "liveblog.video_upload",
+    "liveblog.instance_settings",
 ]
 
 RESOURCE_METHODS = ["GET", "POST"]


### PR DESCRIPTION
### Purpose

This PR introduces a new database collection to store instance settings in JSON format. The purpose of these changes is to ensure that instance configurations are both flexible and robust, allowing settings to be defined and adjusted during deployment and throughout the lifecycle of the instance. The new settings mechanism includes validation to prevent configurations that could disrupt application functionality.


### What has changed

- New DB Collection: Implemented a collection in the database to store instance settings as JSON. This allows dynamic and flexible configuration management.
- Schema Validation: Added schema validation logic to ensure the integrity of the JSON data, protecting the application from potential misconfiguration.
- Default Configuration Fixture: Introduced a fixture file containing default instance settings. This fixture ensures that necessary settings are established during initial deployment.
- Conditional Update Logic: Developed logic to compare existing instance settings against the default provided in the fixture. This update process preserves existing settings by only adding new keys that are missing from the current configuration.

### Steps to test

1. Check out to the branch
2. Send a POST request to add new instance settings: 
```
curl --location --request POST 'http://127.0.0.1:5000/api/instance_settings' \
--header 'Authorization: <basic_auth_token>' \
--header 'Content-Type: application/json' \
--data-raw '{
    "settings": {
       "solo": {
            "features": {
                "syndication": true,
                "marketplace": false
            },
            "limits": {
                "blogs": 1,
                "themes": 1,
                "blog_members": 1
            }
        },
        "team": {
            "features": {
                "syndication": true,
                "marketplace": true
            },
            "limits": {
                "blogs": 3,
                "themes": 6,
                "blog_members": 5
            }
        },
        "network": 1
    }
}'
```
3. Send a GET request to view instance settings:
```
curl --location --request GET 'http://127.0.0.1:5000/api/instance_settings' \
--header 'Authorization: <basic_auth_token>' 
```
4. Send another POST request to updated existing settings giving precedence to existing config values:
```
curl --location --request POST 'http://127.0.0.1:5000/api/instance_settings' \
--header 'Authorization: <basic_auth_token>' \
--header 'Content-Type: application/json' \
--data-raw '{
    "settings": {
        "one-time-event": {
            "features": {
                "syndication": false,
                "marketplace": false
            },
            "limits": {
                "blogs": 1,
                "themes": 1,
                "blog_members": 2
            }
        },
        "uni": {
            "features": {
                "syndication": true,
                "marketplace": false
            },
            "limits": {
                "blogs": 1,
                "themes": 2,
                "blog_members": 3
            }
        },
        "solo": {
            "features": {
                "syndication": true,
                "marketplace": false
            },
            "limits": {
                "blogs": 1,
                "themes": 14,
                "blog_members": 1
            }
        },
        "team": {
            "features": {
                "syndication": true,
                "marketplace": true
            },
            "limits": {
                "blogs": 3,
                "themes": 6,
                "blog_members": 5
            }
        },
        "network": 1
    }
}'
```
4. Send another GET request to view instance settings. You will note that both `uni` and `one-time-event` have been added to the existing config. Also, you will note that even though the new request has set `solo.limits.themes` as 14, the previous value of 1 is retained.
5. To test validation, send a POST request with either a missing key or a non-integer value such as the following: 
```
curl --location --request POST 'http://127.0.0.1:5000/api/instance_settings' \
--header 'Authorization: <basic_auth_token>' \
--header 'Content-Type: application/json' \
--data-raw '{
   "settings": {
        "one-time-event": {
            "features": {
                "syndication": false,
                "marketplace": "false"
            },
            "limits": {
                "blogs": 1,
                "themes": 0
            }
        }
    }
}'
```
You should get the following error response listing all areas with an error: 
```
{
    "_error": {
        "code": 400,
        "message": "Validation errors for config occurred: The 'marketplace' in 'features' for 'one-time-event' must be a <class 'bool'>., The 'themes' in 'limits' for 'one-time-event' must be at least 1., Missing 'blog_members' in 'limits' for 'one-time-event'."
    },
    "_status": "ERR"
}
```

Resolves: [LBSD-2782](https://sofab.atlassian.net/browse/LBSD-2782)

[LBSD-2782]: https://sofab.atlassian.net/browse/LBSD-2782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ