### PR TITLE
[LBSD-2791] - Reverts #1368

### DIFF
--- a/client/app/scripts/liveblog-edit/module.js
+++ b/client/app/scripts/liveblog-edit/module.js
@@ -1,3 +1,4 @@
+
 /**
  * This file is part of Superdesk.
  *
@@ -167,10 +168,6 @@ const app = angular.module('liveblog.edit',
 
                 SirTrevor.EventBus.on('block:create:existing', removeEmptyBlockExceptTheBlock);
                 SirTrevor.EventBus.on('block:create:new', removeEmptyBlockExceptTheBlock);
-
-                // Trigger a click event on the '.st-block-controls__top' element to activate the
-                // block controls immediately when the editor is rendered
-                $('.st-block-controls__top').click();
             },
             blockTypes: ['Text', 'Image', 'Embed', 'Quote', 'Comment', 'Poll', 'Video'],
             // render a default block when the editor is loaded

--- a/client/spec/editor_contribution_posts_spec.js
+++ b/client/spec/editor_contribution_posts_spec.js
@@ -69,8 +69,8 @@ describe('Contributions Posts', function() {
             var draft = contributions.get(0);
             contributions.edit(draft);
             var editor = blog.openEditor();
-            expect(editor.quoteElement.getText()).toEqual(contrib.quote);
-            editor.textElement.clear().sendKeys('update');
+            expect(editor.textElement.getText()).toEqual(contrib.body);
+            editor.quoteElement.clear().sendKeys('update');
             editor.saveContribution();
             blog.openContributions().expectPost(0, 'update');
             expect(contributions.all().count()).toBe(1);

--- a/client/spec/editor_embed_post_spec.js
+++ b/client/spec/editor_embed_post_spec.js
@@ -18,6 +18,7 @@ describe('editor embed:', function() {
     if (process.env.IFRAMELY_KEY) {
         it('add a youtube iframe in the editor', function() {
             var editor = blogs.openBlog(0).editor
+                                .addTop()
                                 .addEmbed();
             // write a youtube url
             editor.embedElement.sendKeys(youtube_url);

--- a/client/spec/editor_imageupload_post_spec.js
+++ b/client/spec/editor_imageupload_post_spec.js
@@ -13,6 +13,7 @@ describe('editor image upload:', function() {
 
     it('upload an image and show it in the editor', function() {
         var editor = blogs.openBlog(0).editor
+                            .addTop()
                             .addImage();
 
         editor.fileElement.sendKeys(rootDir + '/app/images/superdesk-icon-large.png');

--- a/client/spec/helpers/pages.js
+++ b/client/spec/helpers/pages.js
@@ -744,8 +744,8 @@ function EditPostPage() {
             author: randomString(10)
         };
         self.textElement.sendKeys(data.body);
-        self.addQuote(data);
-        
+        self.addTop()
+            .addQuote(data);
         return data;
     };
 

--- a/client/spec/poll_spec.js
+++ b/client/spec/poll_spec.js
@@ -10,6 +10,7 @@ describe('Poll functionality', function() {
 
     it('can add option in poll block', function() {
           var editor = blogs.openBlog(0).editor
+                              .addTop()
                               .addPoll()
                               .addOption();
           var optionsCount = element.all(by.css('.poll_option_container input[type="text"]')).count();
@@ -18,6 +19,7 @@ describe('Poll functionality', function() {
   
     it('can remove option in poll block', function() {
           var editor = blogs.openBlog(0).editor
+                              .addTop()
                               .addPoll()
                               .removeOption();
           var optionsCount = element.all(by.css('.poll_option_container input[type="text"]')).count();
@@ -26,6 +28,7 @@ describe('Poll functionality', function() {
   
     it('can set days, hours, and minutes in poll block', function() {
           var editor = blogs.openBlog(0).editor
+                              .addTop()
                               .addPoll()
                               .setDays(2)
                               .setHours(3)
@@ -40,6 +43,7 @@ describe('Poll functionality', function() {
 
     it('can limit hours to 24 and minutes to 60 in poll block', function() {
           var editor = blogs.openBlog(0).editor
+                              .addTop()
                               .addPoll()
                               .setHours(50)
                               .setMinutes(100);
@@ -51,6 +55,7 @@ describe('Poll functionality', function() {
 
     it('can reset the poll block', function() {
           var editor = blogs.openBlog(0).editor
+                              .addTop()
                               .addPoll()
                               .setDays(2)
                               .setHours(3)


### PR DESCRIPTION
### Purpose

This PR reverts #1368 [LBSD-2774](https://github.com/liveblog/liveblog/pull/1368) reversing the changes made due to the introduction of an editor reorder bug when editing. 

### What has changed
- **Reverting back changes** - Changes made in LBSD-2774 have been reverted
- **Post types don't appear by default** - This reversion results in the default behavior where the "Add Content Here" must be clicked to show post types. A better way to implement this will be done in a subsequent PR.

### Steps to test
1. Navigate to the Editor's interface.
2. The block options shouldn't be shown until the user clicks "Add Content Here"
3. Create a new post with multiple items and publish it. 
4. Edit the post and the items should appear in order on the Editor panel.


Resolves: [LBSD-2791](https://sofab.atlassian.net/browse/LBSD-2791)

[LBSD-2774]: https://sofab.atlassian.net/browse/LBSD-2774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LBSD-2791]: https://sofab.atlassian.net/browse/LBSD-2791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ