### PR TITLE
[LBSD-2816] - Facebook embeds not loading on Editor

### DIFF
--- a/client/app/scripts/liveblog-edit/components/itemEmbedFacebook.tsx
+++ b/client/app/scripts/liveblog-edit/components/itemEmbedFacebook.tsx
@@ -52,7 +52,7 @@ export const ItemEmbedFacebook: React.FunctionComponent<IProps> = (props) => {
     }, []);
 
     useEffect(() => {
-        if (!isLoading && (window as any)?.FB) {
+        if (!isLoading && window?.FB) {
             window.FB.XFBML.parse();
         }
     }, [isLoading, props.url]);

--- a/client/app/scripts/liveblog-edit/components/itemEmbedFacebook.tsx
+++ b/client/app/scripts/liveblog-edit/components/itemEmbedFacebook.tsx
@@ -1,0 +1,62 @@
+/* eslint-disable react/no-multi-comp */
+import React, { CSSProperties, useEffect, useState } from 'react';
+import { PlaceholderEmbed } from 'react-social-media-embed';
+import { IItemMeta } from './itemEmbedInfo';
+
+interface IProps extends IItemMeta {
+    style?: CSSProperties | undefined;
+}
+
+const loadFacebookLib = (callback: () => void) => {
+    const tag = 'script';
+    const id = 'facebook-js';
+    const firstScript = document.getElementsByTagName(tag)[0];
+
+    if (document.getElementById(id)) {
+        callback();
+        return;
+    }
+
+    const scriptElem = document.createElement(tag);
+
+    scriptElem.id = id;
+    scriptElem.src = 'https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v12.0';
+    scriptElem.onload = () => callback();
+
+    firstScript.parentNode.insertBefore(scriptElem, firstScript);
+};
+
+const RenderPlaceHolder = ({ url }: { url: string }) => {
+    return (
+        <PlaceholderEmbed
+            linkText="View post on Facebook"
+            url={url}
+            // @ts-ignore:next-line
+            style={{ maxWidth: 550, height: 600 }}
+        />
+    );
+};
+
+export const ItemEmbedFacebook: React.FunctionComponent<IProps> = (props) => {
+    const [isLoading, setLoading] = useState(true);
+
+    useEffect(() => {
+        loadFacebookLib(() => {
+            setLoading(false);
+        });
+    }, []);
+
+    useEffect(() => {
+        if (!isLoading && (window as any)?.FB) {
+            (window as any)?.FB?.XFBML?.parse();
+        }
+    }, [isLoading, props.url]);
+
+    return (
+        <div>
+            <div className="fb-post" data-href={props.url} data-width="500" style={props.style}>
+                {isLoading && <RenderPlaceHolder url={props.url} />}
+            </div>
+        </div>
+    );
+};

--- a/client/app/scripts/liveblog-edit/components/itemEmbedFacebook.tsx
+++ b/client/app/scripts/liveblog-edit/components/itemEmbedFacebook.tsx
@@ -3,6 +3,12 @@ import React, { CSSProperties, useEffect, useState } from 'react';
 import { PlaceholderEmbed } from 'react-social-media-embed';
 import { IItemMeta } from './itemEmbedInfo';
 
+declare global {
+    interface Window {
+        FB: any;
+    }
+}
+
 interface IProps extends IItemMeta {
     style?: CSSProperties | undefined;
 }
@@ -31,7 +37,6 @@ const RenderPlaceHolder = ({ url }: { url: string }) => {
         <PlaceholderEmbed
             linkText="View post on Facebook"
             url={url}
-            // @ts-ignore:next-line
             style={{ maxWidth: 550, height: 600 }}
         />
     );
@@ -48,7 +53,7 @@ export const ItemEmbedFacebook: React.FunctionComponent<IProps> = (props) => {
 
     useEffect(() => {
         if (!isLoading && (window as any)?.FB) {
-            (window as any)?.FB?.XFBML?.parse();
+            window.FB.XFBML.parse();
         }
     }, [isLoading, props.url]);
 

--- a/client/app/scripts/liveblog-edit/components/itemEmbedRender.tsx
+++ b/client/app/scripts/liveblog-edit/components/itemEmbedRender.tsx
@@ -30,6 +30,8 @@ export const ItemEmbedRender: React.FunctionComponent<IProps> = (props) => {
                     // @ts-ignore:next-line
                     style={{ maxWidth: 550 }}
                     width="100%"
+                    retryDelay={1000}
+                    debug={true}
                 />
                 <ItemEmbedInfo {...props} original_url={props.url} />
             </>

--- a/client/app/scripts/liveblog-edit/components/itemEmbedRender.tsx
+++ b/client/app/scripts/liveblog-edit/components/itemEmbedRender.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { FacebookEmbed, TwitterEmbed } from 'react-social-media-embed';
+import { TwitterEmbed } from 'react-social-media-embed';
 import { ItemEmbedGeneric } from './itemEmbedGeneric';
 import { IItemMeta, ItemEmbedInfo } from './itemEmbedInfo';
 import { ItemEmbedInstagram } from './itemEmbedInstagram';
+import { ItemEmbedFacebook } from './itemEmbedFacebook';
 
 interface IProps extends IItemMeta {
     text: string;
@@ -24,14 +25,9 @@ export const ItemEmbedRender: React.FunctionComponent<IProps> = (props) => {
     case 'Facebook':
         return (
             <>
-                <FacebookEmbed
-                    url={props.url}
-                    linkText={props.title}
-                    // @ts-ignore:next-line
-                    style={{ maxWidth: 550 }}
-                    width="100%"
-                    retryDelay={1000}
-                    debug={true}
+                <ItemEmbedFacebook
+                    {...props}
+                    style={{ maxWidth: 550, width: '100%' }}
                 />
                 <ItemEmbedInfo {...props} original_url={props.url} />
             </>

--- a/client/app/scripts/liveblog-edit/views/main.ng1
+++ b/client/app/scripts/liveblog-edit/views/main.ng1
@@ -315,6 +315,7 @@
             </header>
             <div class="content content--timeline" lr-infinite-scroll="fetchNewTimelinePage">
                 <div>
+                    <div id="fb-root"></div>
                     <lb-posts-list ng-show="!blogEdit.timelineStickyInstance.isPostsEmpty() &&
                         !blogEdit.timelineStickyInstance.hideSticky" data-test-id="timeline-posts-pinned"
                         class="timeline-posts-list pinned" lb-posts-instance="blogEdit.timelineStickyInstance"

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "liveblog-client",
-  "version": "3.85.1-rc1",
+  "version": "3.90.0-rc2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1254,6 +1254,11 @@
       "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
       "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==",
       "dev": true
+    },
+    "@types/youtube-player": {
+      "version": "5.5.11",
+      "resolved": "https://registry.npmjs.org/@types/youtube-player/-/youtube-player-5.5.11.tgz",
+      "integrity": "sha512-pM41CDBqJqBmTeJWnF7NOGz82IQoYOhqzMYXv5vKCXBqGiYSLldxMtpCk6KAEtADTy49S45AriYaCaZyeUX38Q=="
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "3.10.1",
@@ -16688,6 +16693,11 @@
         "use-sidecar": "^1.1.2"
       }
     },
+    "react-html-props": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/react-html-props/-/react-html-props-2.0.9.tgz",
+      "integrity": "sha512-Q9wIP8hs4HFUb3CDh5tF1nKgZ4S9odU07tR/lZ+/9ePv+psxRy+mUn7ujjrCGwtrLA52AI41fXWr425yK1iyTA=="
+    },
     "react-input-autosize": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-3.0.0.tgz",
@@ -16803,27 +16813,29 @@
       }
     },
     "react-social-media-embed": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/react-social-media-embed/-/react-social-media-embed-2.3.4.tgz",
-      "integrity": "sha512-2GAXr5V43yRuKhWeLFwhifuPyYUBTAoP/Rw68JxDdZyILc0pgwb80xUkLYWvYBDIp+f+ee/LNWWj/ZaiNceKTA==",
+      "version": "2.5.13",
+      "resolved": "https://registry.npmjs.org/react-social-media-embed/-/react-social-media-embed-2.5.13.tgz",
+      "integrity": "sha512-9udbyUZpG8lXhDzDHH6ceDZfhW7QGg2WoVjJD6F8PTOXJoULZTkvLV7vYpqeWthqP33iwagLEHo7goJVDuL7ug==",
       "requires": {
-        "classnames": "^2.3.2",
-        "react-sub-unsub": "^2.1.6",
+        "@types/youtube-player": "^5.5.5",
+        "classnames": "^2.5.1",
+        "react-html-props": "^2.0.3",
+        "react-sub-unsub": "^2.2.1",
         "react-twitter-embed": "^4.0.4",
         "react-youtube": "^10.1.0"
       },
       "dependencies": {
         "classnames": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
-          "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+          "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
         }
       }
     },
     "react-sub-unsub": {
-      "version": "2.1.11",
-      "resolved": "https://registry.npmjs.org/react-sub-unsub/-/react-sub-unsub-2.1.11.tgz",
-      "integrity": "sha512-FNKy0uD5wSieRE+l5RXaS0bUu6cR8XAXLDwOJnvSDGBMHcWVb1dod8ZkXYjPKtKR74tjYCEpMWcEAWCOoWNXxQ=="
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/react-sub-unsub/-/react-sub-unsub-2.2.7.tgz",
+      "integrity": "sha512-b2o0mIW8G4Yb3aaKxFB9iiCCHxCDGmogy+493oQpEJHjBy/hl6uf+6RhAinqKWRwi1fvO6mGIMVGsf2XYLL38g=="
     },
     "react-textarea-autosize": {
       "version": "5.2.1",

--- a/client/package.json
+++ b/client/package.json
@@ -113,7 +113,7 @@
     "rangy": "1.3.0",
     "raven-js": "3.22.3",
     "react-select": "^3.0.4",
-    "react-social-media-embed": "^2.3.4",
+    "react-social-media-embed": "^2.5.13",
     "sanitize-html": "^2.7.0",
     "sir-trevor": "git+https://github.com/liveblog/sir-trevor-js",
     "styled-components": "^5.1.1",


### PR DESCRIPTION
### Purpose
This PR fixes a bug where the Facebook embeds are not loading on Editor.

### What has changed

- Update the `react-social-media-embed` package.
- Added a new `itemEmbedFacebook` component to load Facebook embeds manually on the Editor. 

### Steps to test
1. Open the Editor.
2. Add a new post which is a Facebook embed. Observe that it loads correctly on the timeline.


Resolves: [LBSD-2816](https://sofab.atlassian.net/browse/LBSD-2816)

[LBSD-2816]: https://sofab.atlassian.net/browse/LBSD-2816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ