### PR TITLE
[LBSD-2814] - Fix Large Index Key issue when running `initialize_data` command

### DIFF
--- a/server/liveblog/prepopulate/app_initialize.py
+++ b/server/liveblog/prepopulate/app_initialize.py
@@ -37,26 +37,10 @@ dictionary:
 __entities__ = OrderedDict(
     [
         ("global_preferences", ("global_preferences.json", ["key"], False)),
-        (
-            "instance_settings",
-            (
-                "instance_settings.json",
-                [
-                    [
-                        ("settings.liveblog-go", pymongo.ASCENDING),
-                        {"sparse": True},
-                    ],
-                    [("settings.uni", pymongo.ASCENDING), {"sparse": True}],
-                    [("settings.solo", pymongo.ASCENDING), {"sparse": True}],
-                    [
-                        ("settings.solo-mobile", pymongo.ASCENDING),
-                        {"sparse": True},
-                    ],
-                    [("settings.team", pymongo.ASCENDING), {"sparse": True}],
-                ],
-                True,
-            ),
-        ),
+        # No index created for instance_settings due to complexity and variability of nested fields,
+        # which can cause issues with MongoDB's index size limits. Using wildcards for indexes can be
+        # implemented later with an update of the mongo version
+        ("instance_settings", ("instance_settings.json", [], True)),
         ("roles", ("roles.json", ["name"], True)),
         ("users", ("users.json", [], False)),
         ("stages", ("stages.json", ["desk"], False)),

--- a/server/liveblog/prepopulate/app_initialize.py
+++ b/server/liveblog/prepopulate/app_initialize.py
@@ -37,7 +37,26 @@ dictionary:
 __entities__ = OrderedDict(
     [
         ("global_preferences", ("global_preferences.json", ["key"], False)),
-        ("instance_settings", ("instance_settings.json", ["settings"], True)),
+        (
+            "instance_settings",
+            (
+                "instance_settings.json",
+                [
+                    [
+                        ("settings.liveblog-go", pymongo.ASCENDING),
+                        {"sparse": True},
+                    ],
+                    [("settings.uni", pymongo.ASCENDING), {"sparse": True}],
+                    [("settings.solo", pymongo.ASCENDING), {"sparse": True}],
+                    [
+                        ("settings.solo-mobile", pymongo.ASCENDING),
+                        {"sparse": True},
+                    ],
+                    [("settings.team", pymongo.ASCENDING), {"sparse": True}],
+                ],
+                True,
+            ),
+        ),
         ("roles", ("roles.json", ["name"], True)),
         ("users", ("users.json", [], False)),
         ("stages", ("stages.json", ["desk"], False)),


### PR DESCRIPTION
### Purpose

This PR fixes an issue that was causing a `WiredTigerIndex::insert: key too large to index` issue when running the `initialize_data` command when initializing the instance settings. This is because the settings index was exceeding MongoDB's index size limit. 

### What has changed
- Changed the index param from `settings` to 5 smaller individual plan indexes. 

### Steps to test
1. Start the docker service and the backend.
2. Run the command `python3 manage.py app:initialize_data;`. Observe that the command runs with no errors.

Resolves: [LBSD-2814](https://sofab.atlassian.net/browse/LBSD-2814)

[LBSD-2814]: https://sofab.atlassian.net/browse/LBSD-2814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ