### PR TITLE
Change `newest_first` and `oldest_first` ordering attribute

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -36,7 +36,7 @@ jobs:
         ports:
           - 6379:6379
       elasticsearch-1.7.2:
-        image: barnybug/elasticsearch:1.7.2
+        image: liveblog3/elasticsearch:1.7.2
         ports:
           - 9200:9200
 

--- a/server/liveblog/blogs/blog.py
+++ b/server/liveblog/blogs/blog.py
@@ -25,15 +25,15 @@ class Blog(AuthorsMixin):
     Utility class to fetch blog data directly from mongo collections.
     """
 
-    order_by = ("_updated", "_created", "order")
+    order_by = ("_updated", "published_date", "order")
     sort = ("asc", "desc")
     ordering = {
-        "newest_first": ("_created", "desc"),
-        "oldest_first": ("_created", "asc"),
+        "newest_first": ("published_date", "desc"),
+        "oldest_first": ("published_date", "asc"),
         "editorial": ("order", "desc"),
     }
     default_ordering = "newest_first"
-    default_order_by = "_created"
+    default_order_by = "published_date"
     default_sort = "desc"
     default_page = 1
     default_page_limit = 25

--- a/server/liveblog/blogs/tests/blog_test.py
+++ b/server/liveblog/blogs/tests/blog_test.py
@@ -15,19 +15,19 @@ class BlogsPostOrderingTestCase(TestCase):
     def test_default_ordering(self):
         # get default ordering, when no values supplied
         order_by, sort = self.blog_instance.get_ordering("")
-        self.assertEqual(order_by, "_created")
+        self.assertEqual(order_by, "published_date")
         self.assertEqual(sort, "desc")
 
     def test_check_newest_first(self):
         ordering = "newest_first"
         order_by, sort = self.blog_instance.get_ordering(ordering)
-        self.assertEqual(order_by, "_created")
+        self.assertEqual(order_by, "published_date")
         self.assertEqual(sort, "desc")
 
     def test_check_oldest_first(self):
         ordering = "oldest_first"
         order_by, sort = self.blog_instance.get_ordering(ordering)
-        self.assertEqual(order_by, "_created")
+        self.assertEqual(order_by, "published_date")
         self.assertEqual(sort, "asc")
 
     def test_check_editorial(self):


### PR DESCRIPTION
### Purpose
There are some cases when the users create a post but do not publish it right away (like scheduled posts). Such posts, could end up not being rendered in the right position when using Newest First or Oldest First tabs in the readers side as it was using `_created` attribute which is assigned at the time the entry is added into the database. To avoid such issues, we need to use `published_date` attribute instead, as this is the one that stores the real date and time when the post is available to the readers

### What has changed
The ordering attribute for the embed generation has been changed from `_created` to `published_date`

### How to test
- Checkout the branch and run the project
- Create a blog, set default ordering to "Newest First" in Theme Settings section
- Create multiple posts. Add a scheduled one that would end up in the middle while you create a publish other posts
- Observe that the scheduled post renders in the right position after reloading the embed side

Resolves: [LBSD-2824]

[LBSD-2824]: https://sofab.atlassian.net/browse/LBSD-2824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ