### PR TITLE
[LBSD-2800] - The list when choosing a list type has UI issues in Firefox

### DIFF
--- a/client/app/scripts/liveblog-edit/styles/liveblog-edit.scss
+++ b/client/app/scripts/liveblog-edit/styles/liveblog-edit.scss
@@ -885,6 +885,9 @@
         border-radius: 2px;
         margin-right: 0px;
         margin-bottom: 1px;
+        height: auto;
+        white-space: normal;
+        word-wrap: break-word;
     }
     max-height: 348px;
     overflow-y: auto;


### PR DESCRIPTION
### Purpose
This PR fixes the issue of Freetypes overlapping each other on the editor

### What has changed
- Added styling to enable word breaks and auto height adjustment for the Freetypes list item.

### Steps to test
1. Navigate to the Editor's interface.
2. Click "Choose Post Type". A popup should show with a list of all post type. The list should be scrollable.

| Original  | New |
| ------------- | ------------- |
| ![image](https://github.com/liveblog/liveblog/assets/14116447/4e68ab79-edba-45ac-bb34-f8856b60a5f5) |   ![image](https://github.com/liveblog/liveblog/assets/14116447/72b38774-3518-4b9c-9277-a6dfc9ba62c5) |


Resolves: [LBSD-2800](https://sofab.atlassian.net/browse/LBSD-2800)

[LBSD-2800]: https://sofab.atlassian.net/browse/LBSD-2800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ