### PR TITLE
[LBSD-2831] - Error when creating 3rd blog for Team package

### DIFF
--- a/server/liveblog/instance_settings/features_service.py
+++ b/server/liveblog/instance_settings/features_service.py
@@ -94,7 +94,7 @@ class FeaturesService:
         limits = self._get_settings_for("limits")
         subscription_limit = limits.get(feature_name, 0)
 
-        return current_usage >= subscription_limit
+        return current_usage > subscription_limit
 
     def _get_settings_for(self, settings_key):
         """


### PR DESCRIPTION
### Purpose

This PR fixes an issue where an error is thrown on the Team package when trying to create a 3rd blog which should be possible since its not beyond it's subscription limit.

### What has changed
- Changed the conditional operator to `>` instead of `>=` since the `current_usage` passed in the function is a summation of active blogs plus the number of new blogs to be made.

### Steps to test
1. Ensure you set `SUBSCRIPTION_LEVEL='team'` in your .env file
2. Run Liveblog
3. Open the Editor and create 3 blogs. Observer that they will be created.
4. Trying to create a 4th blog will show a modal indicating you cannot create more blogs.


Resolves: [LBSD-2831](https://sofab.atlassian.net/browse/LBSD-2831)

[LBSD-2831]: https://sofab.atlassian.net/browse/LBSD-2831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ