### PR TITLE
[LBSD-2863] - Investigate `blog_preferences.theme` lookup 

### DIFF
--- a/client/app/scripts/liveblog-themes/module.js
+++ b/client/app/scripts/liveblog-themes/module.js
@@ -133,9 +133,7 @@ import listTpl from 'scripts/liveblog-themes/views/list.ng1';
                 themes.forEach((theme) => {
                     // create criteria to load blogs with the theme.
                     const criteria = {
-                        source: {
-                            query: {match: {'blog_preferences.theme': theme.name}},
-                        },
+                        where: JSON.stringify({'blog_preferences.theme': theme.name}),
                     };
 
                     api.blogs.query(criteria).then((data) => {

--- a/server/liveblog/blogs/blogs.py
+++ b/server/liveblog/blogs/blogs.py
@@ -13,6 +13,7 @@ import logging
 import datetime
 
 from bson.objectid import ObjectId
+from eve.utils import ParsedRequest
 from flask import current_app as app
 from flask import render_template
 from superdesk import get_resource_service
@@ -107,6 +108,17 @@ def send_email_to_added_members(blog, recipients, blog_url):
 
 class BlogService(BaseService):
     notification_key = "blog"
+
+    def get(self, req, lookup):
+        if req is None:
+            req = ParsedRequest()
+
+        if req.where:
+            docs = super().get_from_mongo(req, lookup)
+        else:
+            docs = super().get(req, lookup)
+
+        return docs
 
     def _update_theme_settings(self, doc, theme_name):
         theme = get_resource_service("themes").find_one(req=None, name=theme_name)

--- a/server/liveblog/blogs/blogs.py
+++ b/server/liveblog/blogs/blogs.py
@@ -110,15 +110,17 @@ class BlogService(BaseService):
     notification_key = "blog"
 
     def get(self, req, lookup):
-        if req is None:
-            req = ParsedRequest()
+        """
+        This `get` method decides whether to fetch data from MongoDB or ElasticSearch based on the presence of a `where` filter.
+        - If `where` is used in the request (e.g., filtering blogs by a non-indexed field like `blog_preferences.theme`), it fetches directly from MongoDB.
+        - Otherwise, it uses the standard get method to retrieve from ElasticSearch.
 
-        if req.where:
-            docs = super().get_from_mongo(req, lookup)
-        else:
-            docs = super().get(req, lookup)
-
-        return docs
+        Returns:
+            The result of the appropriate fetch method based on the request type.
+        """
+        req = req or ParsedRequest()
+        method = super().get_from_mongo if req.where else super().get
+        return method(req, lookup)
 
     def _update_theme_settings(self, doc, theme_name):
         theme = get_resource_service("themes").find_one(req=None, name=theme_name)

--- a/server/liveblog/themes/tests/theme_settings_test.py
+++ b/server/liveblog/themes/tests/theme_settings_test.py
@@ -132,7 +132,7 @@ class ThemeSettingsTestCase(TestCase):
             {
                 "_created": "2018-03-27T12:04:58+00:00",
                 "_etag": "b962afec2413ddf43fcf0273a1a422a2fec1e34d",
-                "_id": "5aba336a4d003d61e663eeeb",
+                "_id": ObjectId("5aba336a4d003d61e663eeeb"),
                 "_links": {
                     "self": {"href": "blogs/5aba336a4d003d61e663eeeb", "title": "Blog"}
                 },
@@ -222,7 +222,7 @@ class ThemeSettingsTestCase(TestCase):
             {
                 "_created": "2018-03-30T10:24:33+00:00",
                 "_etag": "8f96666a3d97401979a79bda82886dd12cc6f272",
-                "_id": "5abe10614d003d5f22ce005e",
+                "_id": ObjectId("5abe10614d003d5f22ce005e"),
                 "_links": {
                     "collection": {"href": "client_blogs", "title": "client_blogs"},
                     "parent": {"href": "/", "title": "home"},
@@ -1441,7 +1441,7 @@ class ThemeSettingsTestCase(TestCase):
         blog_title = data.find('"title": "title: end to end Five"')
         self.assertNotEqual(blog_title, -1)
         # blog created date exists in response
-        test_created = data.find('"_created": "2018-03-27T12:04:58+0000"')
+        test_created = data.find('"_created": "2018-03-27T12:04:58+00:00"')
         self.assertNotEqual(test_created, -1)
         # test blog_preferences
         blog_pref = data.find(
@@ -1471,7 +1471,7 @@ class ThemeSettingsTestCase(TestCase):
         blog_title = data.find('"title: end to end Seven"')
         self.assertNotEqual(blog_title, -1)
         # blog created date exists in response
-        test_created = data.find('"_created": "2018-03-30T10:24:33+0000"')
+        test_created = data.find('"_created": "2018-03-30T10:24:33+00:00"')
         self.assertNotEqual(test_created, -1)
         # test blog_preferences
         blog_pref = data.find(

--- a/server/liveblog/themes/themes.py
+++ b/server/liveblog/themes/themes.py
@@ -482,7 +482,7 @@ class ThemesService(BaseService):
 
             # Set theme settings for blogs using previous theme.
             blogs_service = get_resource_service("blogs")
-            blogs = blogs_service.get(
+            blogs = blogs_service.get_from_mongo(
                 req=None, lookup={"blog_preferences.theme": previous_theme["name"]}
             )
             for blog in blogs:
@@ -651,7 +651,7 @@ class ThemesService(BaseService):
 
         # Update all the blogs using the removed theme and assign the default theme.
         blogs_service = get_resource_service("blogs")
-        blogs = blogs_service.get(
+        blogs = blogs_service.get_from_mongo(
             req=None, lookup={"blog_preferences.theme": deleted_theme["name"]}
         )
 


### PR DESCRIPTION
### Purpose

This PR fixes the `blog_preferences.theme` lookup failure by making use of the `get_from_mongo` function to instead use Mongo and not Elastic. This PR also fixes [LBSD-2861](https://github.com/liveblog/liveblog/pull/1410)

### What has changed

- Changed the blogs `get` api to use `get_from_mongo` if the `where` arg is present in the params. 
- Changed to `get_from_mongo` where `blog_preferences.theme` is used in the codebase.
- Changed the criteria on the front end to use the where keyword for theme count filtration.

### Steps to test

1. Open the Editor
2. Create several blogs with several themes.
3. Open the side menu and head to the "Theme Manager".
4. Observe that for each theme, the number of blogs using the theme is accurate.


Resolves: [LBSD-2863](https://sofab.atlassian.net/browse/LBSD-2863)

[LBSD-2861]: https://sofab.atlassian.net/browse/LBSD-2861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LBSD-2863]: https://sofab.atlassian.net/browse/LBSD-2863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ