### PR TITLE
[LBSD-2879] - Refactor clientpolls to handle etag consistency

### DIFF
--- a/server/liveblog/client_modules/client_modules.py
+++ b/server/liveblog/client_modules/client_modules.py
@@ -505,9 +505,9 @@ def create_amp_comment():
     client_domain = data.get("__amp_source_origin")
     resp.headers["Access-Control-Allow-Origin"] = client_domain
     resp.headers["AMP-Access-Control-Allow-Source-Origin"] = client_domain
-    resp.headers["Access-Control-Expose-Headers"] = (
-        "AMP-Access-Control-Allow-Source-Origin"
-    )
+    resp.headers[
+        "Access-Control-Expose-Headers"
+    ] = "AMP-Access-Control-Allow-Source-Origin"
     return resp
 
 

--- a/server/liveblog/client_modules/client_modules.py
+++ b/server/liveblog/client_modules/client_modules.py
@@ -3,6 +3,7 @@ import logging
 
 from distutils.util import strtobool
 from eve.utils import config, date_to_str
+from eve.io.base import DataLayer
 from flask_cors import CORS
 from flask import Blueprint, request
 from flask import current_app as app
@@ -206,13 +207,47 @@ class ClientPollsResource(PollsResource):
 
 
 class ClientPollsService(PollsService):
+    """
+    This service handles client polls, enabling vote updates.
+    Voting operations currently rely on the PATCH method to update resources.
+
+    **TODO:**
+
+    * Use a custom voting endpoint to allow the use of `rate_limit` decorator
+    """
+
+    def update(self, id, updates, original):
+        """
+        Updates a poll document with the provided updates and ensures ETag consistency.
+
+        The `_etag` from the original document is copied into the `updates` because the PATCH request goes
+        through an internal patch command that would otherwise generate a new ETag. By copying the last ETag
+        manually, we ensure that the `system_update` uses the original ETag for consistency in update behavior.
+        """
+        updates["_etag"] = original.get("_etag")
+
+        try:
+            self.system_update(id, updates, original)
+        except DataLayer.OriginalChangedError:
+            poll = self.find_one(req=None, _id=id)
+            self.system_update(id, updates, poll)
+
     def on_updated(self, updates, original):
+        """
+        Performs actions when a poll has been successfully updated.
+
+        After updating the poll, this method checks for any associated client posts that reference the updated
+        poll and updates the `content_updated_date` for these posts to reflect that the
+        poll content has changed. This then ensures the clients get the poll updates on the embeds
+        """
         super().on_updated(updates, original)
 
         poll_id = str(original.get("_id"))
         blog_id = original.get("blog")
 
-        for post in get_resource_service("client_posts").find({"blog": blog_id}):
+        for post in get_resource_service("client_posts").find(
+            {"blog": blog_id, "particular_type": "post"}
+        ):
             for assoc in post_utils.get_associations(post):
                 if assoc.get("residRef") == poll_id:
                     updated_post = post.copy()
@@ -470,9 +505,9 @@ def create_amp_comment():
     client_domain = data.get("__amp_source_origin")
     resp.headers["Access-Control-Allow-Origin"] = client_domain
     resp.headers["AMP-Access-Control-Allow-Source-Origin"] = client_domain
-    resp.headers[
-        "Access-Control-Expose-Headers"
-    ] = "AMP-Access-Control-Allow-Source-Origin"
+    resp.headers["Access-Control-Expose-Headers"] = (
+        "AMP-Access-Control-Allow-Source-Origin"
+    )
     return resp
 
 


### PR DESCRIPTION
### Purpose

Refactor ClientPollsService to override etag change from patch update to use the previous etag

### What has changed

- Added `update` function to ClientPollsService to handle poll update and etag consistency
- Added necessary documentation

### Steps to test

1. Open the Editor and publish a new poll.
2. Open the preview and place a vote.
3. Observe that the request to fetch a poll first to get the etag has the same etag as the response from the patch request


Resolves: [LBSD-2879](https://sofab.atlassian.net/browse/LBSD-2879)

[LBSD-2879]: https://sofab.atlassian.net/browse/LBSD-2879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ