### PR TITLE
[LBSD-2876] - After switching to child theme and getting error, going back to Default theme is not possible

### DIFF
--- a/client/app/scripts/liveblog-edit/blog.service.js
+++ b/client/app/scripts/liveblog-edit/blog.service.js
@@ -88,7 +88,7 @@ export default function blogService(api, $q, $rootScope, config, notify) {
             const errorMessage = `There has been an error while generating the embed for the
                 current blog. Please try with another theme and contact our Support Team
                 and provide this error: "${eventData.error}". The embed generation has fallen
-                back to the Default theme for the current blog.`;
+                back to the Default SEO theme for the current blog.`;
 
             notify.error(errorMessage, 30000);
             Storage.write(storeKey, '1', expiry);

--- a/client/app/scripts/liveblog-edit/blog.service.js
+++ b/client/app/scripts/liveblog-edit/blog.service.js
@@ -87,7 +87,8 @@ export default function blogService(api, $q, $rootScope, config, notify) {
 
             const errorMessage = `There has been an error while generating the embed for the
                 current blog. Please try with another theme and contact our Support Team
-                and provide this error: "${eventData.error}"`;
+                and provide this error: "${eventData.error}. The embed generation has fallen
+                back to the Default theme for the current blog."`;
 
             notify.error(errorMessage, 30000);
             Storage.write(storeKey, '1', expiry);

--- a/client/app/scripts/liveblog-edit/blog.service.js
+++ b/client/app/scripts/liveblog-edit/blog.service.js
@@ -87,8 +87,8 @@ export default function blogService(api, $q, $rootScope, config, notify) {
 
             const errorMessage = `There has been an error while generating the embed for the
                 current blog. Please try with another theme and contact our Support Team
-                and provide this error: "${eventData.error}. The embed generation has fallen
-                back to the Default theme for the current blog."`;
+                and provide this error: "${eventData.error}". The embed generation has fallen
+                back to the Default theme for the current blog.`;
 
             notify.error(errorMessage, 30000);
             Storage.write(storeKey, '1', expiry);

--- a/server/liveblog/blogs/tasks.py
+++ b/server/liveblog/blogs/tasks.py
@@ -59,7 +59,20 @@ def publish_embed(blog_id, theme=None, output=None, api_host=None):
 
         logger.info('generate_embed_fallback for blog "{}" started.'.format(blog_id))
         try:
-            html = embed(blog_id, "default", output, api_host)
+            theme = "default"
+            updates = {}
+            blogs = get_resource_service("blogs")
+            html = embed(blog_id, theme, output, api_host)
+
+            # Also update the blog theme and theme settings
+            blog_id, blog = get_blog(blog_id)
+
+            # Ensure blog_preferences exists in the updates dictionary
+            updates["blog_preferences"] = blog.get("blog_preferences", {})
+            updates["blog_preferences"]["theme"] = theme
+
+            blogs._update_theme_settings(updates, theme)
+            blogs.system_update(blog_id, updates, blog)
             logger.info(
                 'generate_embed_fallback for blog "{}" finished.'.format(blog_id)
             )

--- a/server/liveblog/blogs/tasks.py
+++ b/server/liveblog/blogs/tasks.py
@@ -37,40 +37,12 @@ from .utils import (
 logger = logging.getLogger("liveblog")
 
 
-def publish_embed_fallback(blog_id, output=None, api_host=None):
-    """
-    Fallback for embed generation using the default theme if primary generation fails.
-
-    If an error occurs during fallback generation, logs the error and generates
-    a default public URL.
-    """
-    logger.info(
-        'publish_embed_fallback for blog "{}"{} started.'.format(
-            blog_id, ' with output="{}"'.format(output.get("name")) if output else ""
-        )
-    )
-    theme = "default"
-
-    try:
-        public_url = publish_embed(blog_id, theme, output, api_host)
-    except Exception as e:
-        exc_info = sys.exc_info()
-        logger.exception(
-            f"Failed embed fallback generation with theme `{theme}`. Error: {e}",
-            exc_info=exc_info,
-        )
-        public_url = build_blog_public_url(app, blog_id, theme)
-
-    logger.info('publish_embed_fallback for blog "{}" finished.'.format(blog_id))
-    return public_url
-
-
 def publish_embed(blog_id, theme=None, output=None, api_host=None):
     """
     Generates the html for the embed file using the `embed` function.
     If the embed fails to generate with a `TemplateNotFound` exception
     it will send a push notification so the user can be notified and it
-    will also trigger the fallback mechanism.
+    will also trigger the fallback mechanism to use the default theme
     """
     try:
         html = embed(blog_id, theme, output, api_host)
@@ -84,7 +56,19 @@ def publish_embed(blog_id, theme=None, output=None, api_host=None):
             exc_info=exc_info,
         )
         notify_about_embed_generation_error(str(e), blog_id, theme)
-        return publish_embed_fallback(blog_id, output, api_host)
+
+        logger.info('generate_embed_fallback for blog "{}" started.'.format(blog_id))
+        try:
+            html = embed(blog_id, "default", output, api_host)
+            logger.info(
+                'generate_embed_fallback for blog "{}" finished.'.format(blog_id)
+            )
+        except Exception as e:
+            exc_info = sys.exc_info()
+            return logger.exception(
+                f"Failed embed fallback generation with theme `{theme}`. Error: {e}",
+                exc_info=exc_info,
+            )
 
     check_media_storage()
     output_id = output["_id"] if output else None

--- a/server/liveblog/blogs/tasks.py
+++ b/server/liveblog/blogs/tasks.py
@@ -37,19 +37,19 @@ from .utils import (
 logger = logging.getLogger("liveblog")
 
 
-def generate_fallback_html(blog_id, output, api_host):
+def generate_fallback_html_url(blog_id, output, api_host):
     """
     This function is called when the primary embed generation fails, and it
-    generates an HTML embed for the blog using the default seo theme. The function
+    generates an HTML embed url for the blog using the default seo theme. The function
     also updates the blog's theme and theme settings to the default theme in the
     database.
     """
-    logger.info(f'generate_fallback_html for blog "{blog_id}" started.')
+    logger.info(f'generate_fallback_html_url for blog "{blog_id}" started.')
 
     theme = "default"
     updates = {}
     blogs = get_resource_service("blogs")
-    html = embed(blog_id, theme, output, api_host)
+    public_url = publish_embed(blog_id, theme, output, api_host)
 
     blog_id, blog = get_blog(blog_id)
 
@@ -59,8 +59,8 @@ def generate_fallback_html(blog_id, output, api_host):
     blogs._update_theme_settings(updates, theme)
     blogs.system_update(blog_id, updates, blog)
 
-    logger.info(f'generate_fallback_html for blog "{blog_id}" finished.')
-    return html
+    logger.info(f'generate_fallback_html_url for blog "{blog_id}" finished.')
+    return public_url
 
 
 def publish_embed(blog_id, theme=None, output=None, api_host=None):
@@ -86,7 +86,7 @@ def publish_embed(blog_id, theme=None, output=None, api_host=None):
         if theme != "default":
             notify_about_embed_generation_error(str(e), blog_id, theme)
             try:
-                html = generate_fallback_html(blog_id, output, api_host)
+                return generate_fallback_html_url(blog_id, output, api_host)
             except Exception as e:
                 exc_info = sys.exc_info()
                 return logger.exception(

--- a/server/liveblog/themes/themes_assets/amp/package.json
+++ b/server/liveblog/themes/themes_assets/amp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "liveblog-amp-theme",
-  "version": "3.4.32",
+  "version": "3.4.33",
   "description": "Liveblog 3 AMP theme",
   "author": "Sourcefabric <contact@sourcefabric.org>",
   "license": "AGPL-3.0",
@@ -9,7 +9,7 @@
     "build": "gulp"
   },
   "dependencies": {
-    "liveblog-default-theme": "3.9.0-dev.0"
+    "liveblog-default-theme": "3.9.0-dev.4"
   },
   "volta": {
     "node": "10.24.1"

--- a/server/liveblog/themes/themes_assets/amp/theme.json
+++ b/server/liveblog/themes/themes_assets/amp/theme.json
@@ -1,7 +1,7 @@
 {
     "label": "Liveblog 3 AMP Theme",
     "name": "amp",
-    "version": "3.4.32",
+    "version": "3.4.33",
     "seoTheme": true,
     "ampTheme": true,
     "extends": "default",

--- a/server/liveblog/themes/themes_assets/simple/package.json
+++ b/server/liveblog/themes/themes_assets/simple/package.json
@@ -1,6 +1,6 @@
 {
   "name": "liveblog-simple-theme",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Liveblog SEO Simple Theme",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -9,7 +9,7 @@
   "license": "AGPL-3.0",
   "main": "index.js",
   "dependencies": {
-    "liveblog-default-theme": "3.9.0-dev.0"
+    "liveblog-default-theme": "3.9.0-dev.4"
   },
   "repository": {
     "type": "git",

--- a/server/liveblog/themes/themes_assets/simple/theme.json
+++ b/server/liveblog/themes/themes_assets/simple/theme.json
@@ -1,7 +1,7 @@
 {
     "label": "Liveblog SEO Simple Theme",
     "name": "simple",
-    "version": "0.3.2",
+    "version": "0.3.3",
     "seoTheme": true,
     "extends": "default",
     "extendsFromPackage": "liveblog-default-theme",


### PR DESCRIPTION
### Purpose

This PR adds a fallback mechanism to revert back to default theme if an embed generation fails on any other blog theme generation.

### What has changed

- Added fallback mechanism for blog embed generation to default theme.
- Updated Simple and AMP theme to use latest dev version of default theme.

### Steps to test

The easiest way to test this would be to mock an exception in the embed generation function. Just throw the exception after line 47 in the code below, restart your services and then update the blog theme. Observe the notification on the UI. Also observe that on refresh the theme is set as the Default theme.

https://github.com/liveblog/liveblog/blob/987a234d2da572a5775c1d8a68897ec483ebf75a/server/liveblog/blogs/tasks.py#L46-L57


### Screenshots of notification to user with fallback info

![image](https://github.com/user-attachments/assets/8292ab26-d846-4ab8-a937-4c825ea03b32) 


Resolves: [LBSD-2876](https://sofab.atlassian.net/browse/LBSD-2876)

[LBSD-2876]: https://sofab.atlassian.net/browse/LBSD-2876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ