### PR TITLE
Remove usages of `notify.pop` as it no longer exists

### DIFF
--- a/client/app/scripts/liveblog-settings/controllers/general-settings.ts
+++ b/client/app/scripts/liveblog-settings/controllers/general-settings.ts
@@ -61,7 +61,6 @@ const LiveblogSettingsController = ($scope, api, $location, notify, gettext, $q)
     };
 
     $scope.saveSettings = () => {
-        notify.pop();
         notify.info(gettext('Saving settings'));
         let patch = {};
         const reqArr = [];
@@ -79,11 +78,9 @@ const LiveblogSettingsController = ($scope, api, $location, notify, gettext, $q)
         });
 
         $q.all(reqArr).then(() => {
-            notify.pop();
             notify.info(gettext('Settings saved successfully'));
             $scope.settingsForm.$setPristine();
         }, () => {
-            notify.pop();
             notify.error(gettext('Saving settings failed. Please try again later'));
         });
     };

--- a/client/app/scripts/liveblog-settings/controllers/instance-settings.ts
+++ b/client/app/scripts/liveblog-settings/controllers/instance-settings.ts
@@ -32,19 +32,16 @@ const LiveblogInstanceSettingsController = (
             return;
         }
 
-        notify.pop();
         notify.info(gettext('Saving instance settings'));
 
         api.instance_settings.save({ settings: updatedSettings })
             .then(() => {
-                notify.pop();
                 notify.info(gettext('Instance settings saved successfully.'));
                 $scope.instanceForm.$setPristine();
             })
             .catch(({ data }) => {
                 const errMsg = data?._issues?.settings || data?._message;
 
-                notify.pop();
                 notify.error(errMsg, 10000);
             });
     };


### PR DESCRIPTION
### Purpose
Fix broken references to removed method from notification module.


### Todo
We should double check all usages of `notify` module across the app to see if the little messages are showing/hiding properly
