### PR TITLE
[LBSD-2903] - Resolve error when deleting comments before publishing

### DIFF
--- a/client/app/scripts/liveblog-edit/posts.service.ts
+++ b/client/app/scripts/liveblog-edit/posts.service.ts
@@ -420,6 +420,12 @@ const postsService = (api, $q, _userList, session) => {
         });
 
         return $q.all(deletePromises).then(() => {
+            /*
+             TODO: Re-implement this logic to permanently delete the post
+             instead of just resetting `groups.refs` as this reserves the
+             posts in the system for no reason.
+            */
+
             angular.extend(removeParams, {
                 groups: [
                     {

--- a/server/liveblog/posts/posts.py
+++ b/server/liveblog/posts/posts.py
@@ -427,7 +427,7 @@ class PostsService(ArchiveService):
                 )
 
         # in the case we have a comment
-        if original["post_status"] == "comment":
+        if original["post_status"] == "comment" and not updates.get("deleted", False):
             item = original["groups"][1]["refs"][0]["item"]
             blog_id_try = item.get("blog")
             blog_id_object = ObjectId(item.get("client_blog", blog_id_try))

--- a/server/liveblog/posts/posts.py
+++ b/server/liveblog/posts/posts.py
@@ -426,7 +426,14 @@ class PostsService(ArchiveService):
                     original.get("blog")
                 )
 
-        # in the case we have a comment
+        """
+        TODO: Review this block of code to understand why we are reassigning
+        the blog ID from updates into the original. This seems unnecessary
+        and should be investigated further.
+        Also, if the comment is marked as deleted in updates, we can safely skip
+        this block since we don’t need to access the comment item anymore thus
+        not causing a key error.
+        """
         if original["post_status"] == "comment" and not updates.get("deleted", False):
             item = original["groups"][1]["refs"][0]["item"]
             blog_id_try = item.get("blog")


### PR DESCRIPTION
### Purpose

This PR resolve an error that occurs when deleting comments on the Editor panel.

### What has changed

- Added a check when updating comments where if the `deleted: True` it skips getting the blog_id from the item as well as checking the comment length.

### Steps to test

1. Open Editor. Create a blog and publish a post. 
2. Go to the Live preview and add a comment.
3. Navigate back to the Editor and open the Comments panel and delete the comment.
4. Observe that the comment is deleted without an errors.


Resolves: [LBSD-2903](https://sofab.atlassian.net/browse/LBSD-2903)


[LBSD-2903]: https://sofab.atlassian.net/browse/LBSD-2903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ