### PR TITLE
[LBSD-2909] Strip html tags from LiveblogPostingSchema's `articleBody`

### DIFF
--- a/server/liveblog/blogposting_schema/utils.py
+++ b/server/liveblog/blogposting_schema/utils.py
@@ -1,5 +1,7 @@
 import json
 import logging
+from bs4 import BeautifulSoup
+
 from liveblog.posts.utils import (
     get_first_item,
     get_first_item_of_type,
@@ -47,6 +49,25 @@ def get_base_image(item):
         return media.get("renditions", {}).get("baseImage")
 
 
+def clean_html_text(html_text):
+    """
+    Cleans HTML text by converting <br> tags to newlines and stripping all other HTML tags.
+
+    This function uses BeautifulSoup with the lxml parser for efficient HTML parsing.
+    It preserves line breaks from <br> tags while removing all other HTML markup.
+
+    Args:
+        html_text (str): The HTML text to clean.
+
+    Returns:
+        str: The cleaned text with <br> tags converted to newlines and all other HTML tags removed.
+    """
+    soup = BeautifulSoup(html_text, "lxml")
+    for br in soup.find_all('br'):
+        br.replace_with('\n')
+    return soup.get_text().strip()
+
+
 def generate_blogupdate(blog, post, theme_settings):
     """
     Generates a BlogPosting object from a blog post.
@@ -77,7 +98,7 @@ def generate_blogupdate(blog, post, theme_settings):
 
     text_item = get_first_item_of_type(items, "text")
     if text_item:
-        blog_posting.article_body = text_item.get("text")
+        blog_posting.article_body = clean_html_text(text_item.get("text"))
 
     image_item = get_first_item_of_type(items, "image")
     if image_item:


### PR DESCRIPTION
### Purpose
To remove the html tags from the schema's article body. At the moment html tags are being rendered and according to the specification, the articleBody should be plain text. 

### What has changed
- Added a small util function to remove the html tags but preserve line breaks (replace `<br>` tags with `\n`)

### To test
- Create a blog with a few posts
- Go to the embed view
- Observe in the `LiveBlogPosting > liveBlogUpdate` that the attribute `articleBody` does not contain html tags

Thanks for checking!

Resolves: [LBSD-2909]


[LBSD-2909]: https://sofab.atlassian.net/browse/LBSD-2909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ